### PR TITLE
Add job similarity and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ The script queries multiple job boards and saves the results to a CSV file for f
 ## Requirements
 
 - Python 3.10+
-- `python-jobspy` package
+- Dependencies listed in `requirements.txt`
 
 Install dependencies via pip:
 
 ```bash
-pip install -U python-jobspy
+pip install -r requirements.txt
 ```
 
 ## Usage
@@ -24,5 +24,7 @@ python job_search_ohio.py
 ```
 
 This will search Indeed, LinkedIn, ZipRecruiter, Glassdoor, and Google Jobs for "Senior Data Engineer" roles located in Ohio. The results will be written to `senior_data_engineer_jobs_ohio.csv` in the repository directory.
+
+When run multiple times, the script compares new postings against those already saved in the CSV. For each new entry it adds `most_similar_post` and `similarity_score` columns indicating the closest previous listing and the cosine similarity score.
 
 Feel free to modify the script or search parameters to suit your needs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-jobspy
+pandas
+scikit-learn


### PR DESCRIPTION
## Summary
- add requirements.txt for dependencies
- compute similarity of new job listings with existing CSV data
- record most similar previous post and similarity score in output
- document new install step and feature in README

## Testing
- `python -m py_compile job_search_ohio.py`

------
https://chatgpt.com/codex/tasks/task_e_687ad123feb48330857615ca56ea6c46