### PR TITLE
Fix missing python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn
 fastapi
 uvicorn
 jinja2
+python-multipart


### PR DESCRIPTION
## Summary
- add `python-multipart` to requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687b82b5a5888330bd06dbcc2b618145