### PR TITLE
Improve job fetch logging with progress page

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -10,3 +10,4 @@ body { font-family: Arial, sans-serif; background: #f4f4f4; color: #333; }
 .bad:hover, .good:hover { opacity: 0.8; }
 .stats-table { width: 100%; border-collapse: collapse; }
 .stats-table th, .stats-table td { border-bottom: 1px solid #ddd; padding: 0.25rem; text-align: left; }
+pre { background: #f0f0f0; padding: 0.5rem; }

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Fetching Jobs{% endblock %}
+{% block content %}
+<h1>Fetching jobs...</h1>
+<pre id="log"></pre>
+<script>
+async function poll() {
+  const r = await fetch('/progress');
+  const data = await r.json();
+  document.getElementById('log').textContent = data.logs.join('\n');
+  if (data.done) {
+    window.location.href = '/swipe';
+  } else {
+    setTimeout(poll, 1000);
+  }
+}
+poll();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add progress logging using a global deque
- fetch jobs in a background task and provide `/progress` endpoint
- new `progress.html` shows realtime updates via polling
- minor style tweak for progress log display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8489b9708330b8f3c82a87b857ac