### PR TITLE
Add Portainer webhook to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,3 +27,5 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
+      - name: Trigger Portainer update
+        run: curl -X POST https://portainer.braed.co/api/stacks/webhooks/3b960aac-ae65-44d1-99d2-a4f2477002e3


### PR DESCRIPTION
## Summary
- trigger the Portainer stack update webhook after pushing the container image

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b84fb6df883309c3cbe82814ff5d8