### PR TITLE
Add build number footer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,8 @@ DATABASE = os.environ.get("DATABASE", "jobs.db")
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
+BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "dev")
+templates.env.globals["build_number"] = BUILD_NUMBER
 
 # Store progress messages for the fetch process
 logger = logging.getLogger("job_fetch")

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -11,3 +11,4 @@ body { font-family: Arial, sans-serif; background: #f4f4f4; color: #333; }
 .stats-table { width: 100%; border-collapse: collapse; }
 .stats-table th, .stats-table td { border-bottom: 1px solid #ddd; padding: 0.25rem; text-align: left; }
 pre { background: #f0f0f0; padding: 0.5rem; }
+.footer { text-align: center; margin-top: 1rem; font-size: 0.8rem; color: #666; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,5 +14,6 @@
   <div class="container">
   {% block content %}{% endblock %}
   </div>
+  <footer class="footer">Build: {{ build_number }}</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display build number across all pages

## Testing
- `python -m py_compile app/main.py job_search_ohio.py`


------
https://chatgpt.com/codex/tasks/task_e_687b90eb963c8330ba3a7dc21b79ff3d