### PR TITLE
Improve site styling and display build number

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ DATABASE = os.environ.get("DATABASE", "jobs.db")
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
-BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "dev")
+BUILD_NUMBER = os.environ.get("GITHUB_RUN_NUMBER") or os.environ.get("BUILD_NUMBER", "dev")
 templates.env.globals["build_number"] = BUILD_NUMBER
 
 # Store progress messages for the fetch process

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,14 +1,12 @@
-body { font-family: Arial, sans-serif; background: #f4f4f4; color: #333; }
+body { font-family: Arial, sans-serif; background: #f8f9fa; color: #333; }
 .nav { margin-bottom: 1rem; }
-.container { max-width: 900px; margin: auto; background: #fff; padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+.container { max-width: 900px; margin: auto; background: #fff; padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); border-radius: 0.25rem; }
 .job-grid { display: flex; gap: 1rem; }
-.job-card { flex: 1; border: 1px solid #ccc; padding: 1rem; background: #fafafa; }
+.job-card { flex: 1; border: 1px solid #ccc; padding: 1rem; background: #fafafa; border-radius: 0.25rem; }
 .job-card.single { max-width: 500px; margin: auto; }
 .swipe-buttons { margin-top: 1rem; display: flex; gap: 1rem; justify-content: center; }
 .good { background: #4caf50; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; cursor: pointer; }
 .bad { background: #f44336; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; text-decoration: none; display: inline-block; text-align: center; }
 .bad:hover, .good:hover { opacity: 0.8; }
-.stats-table { width: 100%; border-collapse: collapse; }
-.stats-table th, .stats-table td { border-bottom: 1px solid #ddd; padding: 0.25rem; text-align: left; }
 pre { background: #f0f0f0; padding: 0.5rem; }
-.footer { text-align: center; margin-top: 1rem; font-size: 0.8rem; color: #666; }
+.footer { text-align: center; margin-top: 2rem; padding-top: 0.5rem; font-size: 0.8rem; color: #888; border-top: 1px solid #eee; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,18 +2,25 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css" />
   <title>{% block title %}Job Ranker{% endblock %}</title>
 </head>
-<body>
-  <nav class="nav">
-    <a href="/">Search</a> |
-    <a href="/swipe">Swipe</a> |
-    <a href="/stats">Stats</a>
+<body class="d-flex flex-column min-vh-100">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container">
+      <a class="navbar-brand" href="/">Job Ranker</a>
+      <div class="navbar-nav">
+        <a class="nav-link" href="/">Search</a>
+        <a class="nav-link" href="/swipe">Swipe</a>
+        <a class="nav-link" href="/stats">Stats</a>
+      </div>
+    </div>
   </nav>
-  <div class="container">
+  <main class="container my-4 flex-fill">
   {% block content %}{% endblock %}
-  </div>
-  <footer class="footer">Build: {{ build_number }}</footer>
+  </main>
+  <footer class="footer text-center mt-auto">Build: {{ build_number }}</footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Fetching Jobs{% endblock %}
 {% block content %}
-<h1>Fetching jobs...</h1>
-<pre id="log"></pre>
+<h1 class="mb-3">Fetching jobs...</h1>
+<pre id="log" class="bg-light p-3 rounded"></pre>
 <script>
 async function poll() {
   const r = await fetch('/progress');

--- a/app/templates/reject.html
+++ b/app/templates/reject.html
@@ -1,16 +1,21 @@
 {% extends "base.html" %}
 {% block title %}Why Not?{% endblock %}
 {% block content %}
-<h1>Why isn't this job a good fit?</h1>
-<div class="job-card single">
-  <h2 class="job-title">{{ job.title }}</h2>
-  <p class="job-company">{{ job.company }}</p>
-  <p class="job-location">{{ job.location }}</p>
+<h1 class="mb-4">Why isn't this job a good fit?</h1>
+<div class="card mb-4 mx-auto" style="max-width: 500px;">
+  <div class="card-body">
+    <h2 class="card-title">{{ job.title }}</h2>
+    <p class="card-subtitle mb-2 text-muted">{{ job.company }}</p>
+    <p class="mb-1">{{ job.location }}</p>
+  </div>
 </div>
 <form method="post" action="/feedback">
   <input type="hidden" name="job_id" value="{{ job.id }}" />
   <input type="hidden" name="liked" value="0" />
-  <label>Reason:<br><textarea name="reason" rows="4" cols="50" required></textarea></label>
-  <br><button class="bad" type="submit">Submit</button>
+  <div class="mb-3">
+    <label class="form-label">Reason</label>
+    <textarea name="reason" rows="4" class="form-control" required></textarea>
+  </div>
+  <button class="btn btn-danger bad" type="submit">Submit</button>
 </form>
 {% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,16 +1,39 @@
 {% extends "base.html" %}
 {% block title %}Fetch Jobs{% endblock %}
 {% block content %}
-<h1>Fetch Job Postings</h1>
+<h1 class="mb-4">Fetch Job Postings</h1>
 <form method="post" action="/fetch">
-  <label>Search term:<br><input type="text" name="search_term" required></label><br>
-  <label>Location:<br><input type="text" name="location" required></label><br>
-  <label>Sources:</label><br>
-  <label><input type="checkbox" name="sites" value="linkedin" checked>LinkedIn</label>
-  <label><input type="checkbox" name="sites" value="indeed" checked>Indeed</label>
-  <label><input type="checkbox" name="sites" value="zip_recruiter" checked>ZipRecruiter</label>
-  <label><input type="checkbox" name="sites" value="glassdoor" checked>Glassdoor</label>
-  <label><input type="checkbox" name="sites" value="google" checked>Google</label>
-  <br><button type="submit">Fetch</button>
+  <div class="mb-3">
+    <label class="form-label">Search term</label>
+    <input type="text" name="search_term" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Location</label>
+    <input type="text" name="location" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Sources</label>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="src-linkedin" name="sites" value="linkedin" checked>
+      <label class="form-check-label" for="src-linkedin">LinkedIn</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="src-indeed" name="sites" value="indeed" checked>
+      <label class="form-check-label" for="src-indeed">Indeed</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="src-zip" name="sites" value="zip_recruiter" checked>
+      <label class="form-check-label" for="src-zip">ZipRecruiter</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="src-glassdoor" name="sites" value="glassdoor" checked>
+      <label class="form-check-label" for="src-glassdoor">Glassdoor</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="src-google" name="sites" value="google" checked>
+      <label class="form-check-label" for="src-google">Google</label>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Fetch</button>
 </form>
 {% endblock %}

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Job Stats{% endblock %}
 {% block content %}
-<h1>Job Rankings</h1>
-<table class="stats-table">
+<h1 class="mb-4">Job Rankings</h1>
+<table class="table table-striped">
   <tr><th>#</th><th>Title</th><th>Company</th><th>ELO</th></tr>
   {% for j in jobs %}
   <tr>

--- a/app/templates/swipe.html
+++ b/app/templates/swipe.html
@@ -1,23 +1,25 @@
 {% extends "base.html" %}
 {% block title %}Swipe Jobs{% endblock %}
 {% block content %}
-<h1>Is this job a good fit?</h1>
-<div class="job-card single">
-  <h2 class="job-title">{{ job.title }}</h2>
-  <p class="job-company">{{ job.company }}</p>
-  <p class="job-location">{{ job.location }}</p>
-  <p class="job-source">{{ job.site }}</p>
-  {% if job.min_amount %}
-  <p class="job-salary">{{ job.min_amount }} - {{ job.max_amount }} {{ job.currency }}</p>
-  {% endif %}
-  <p class="job-desc">{{ job.description[:200] }}...</p>
-  <div class="swipe-buttons">
-    <form method="post" action="/feedback">
-      <input type="hidden" name="job_id" value="{{ job.id }}" />
-      <input type="hidden" name="liked" value="1" />
-      <button class="good" type="submit">✔</button>
-    </form>
-    <a class="bad" href="/reject/{{ job.id }}">✖</a>
+<h1 class="mb-4">Is this job a good fit?</h1>
+<div class="card mb-4 mx-auto" style="max-width: 500px;">
+  <div class="card-body">
+    <h2 class="card-title">{{ job.title }}</h2>
+    <p class="card-subtitle mb-2 text-muted">{{ job.company }}</p>
+    <p class="mb-1">{{ job.location }}</p>
+    <p class="mb-1">{{ job.site }}</p>
+    {% if job.min_amount %}
+    <p class="mb-1">{{ job.min_amount }} - {{ job.max_amount }} {{ job.currency }}</p>
+    {% endif %}
+    <p>{{ job.description[:200] }}...</p>
   </div>
+</div>
+<div class="d-flex justify-content-center gap-3 swipe-buttons">
+  <form method="post" action="/feedback">
+    <input type="hidden" name="job_id" value="{{ job.id }}" />
+    <input type="hidden" name="liked" value="1" />
+    <button class="btn btn-success good" type="submit">✔</button>
+  </form>
+  <a class="btn btn-danger bad" href="/reject/{{ job.id }}">✖</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- pull bootstrap from CDN and style pages
- show GitHub Actions build number via `GITHUB_RUN_NUMBER`
- convert pages to use bootstrap components
- tweak footer styles

## Testing
- `python -m py_compile app/main.py`
- `python -m py_compile job_search_ohio.py`


------
https://chatgpt.com/codex/tasks/task_e_687ba86a240c8330a4d3714e61a2630e