### PR TITLE
Handle missing job descriptions

### DIFF
--- a/app/templates/swipe.html
+++ b/app/templates/swipe.html
@@ -11,7 +11,11 @@
     {% if job.min_amount %}
     <p class="mb-1">{{ job.min_amount }} - {{ job.max_amount }} {{ job.currency }}</p>
     {% endif %}
+    {% if job.description %}
     <p>{{ job.description[:200] }}...</p>
+    {% else %}
+    <p>No description available.</p>
+    {% endif %}
   </div>
 </div>
 <div class="d-flex justify-content-center gap-3 swipe-buttons">


### PR DESCRIPTION
## Summary
- fix swipe.html template to avoid slicing None descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb086b240833083c4c4649f51b861