### PR TITLE
Add links to job postings

### DIFF
--- a/app/templates/reject.html
+++ b/app/templates/reject.html
@@ -4,7 +4,7 @@
 <h1 class="mb-4">Why isn't this job a good fit?</h1>
 <div class="card mb-4 mx-auto" style="max-width: 500px;">
   <div class="card-body">
-    <h2 class="card-title">{{ job.title }}</h2>
+    <h2 class="card-title"><a href="{{ job.job_url }}" target="_blank" rel="noopener">{{ job.title }}</a></h2>
     <p class="card-subtitle mb-2 text-muted">{{ job.company }}</p>
     <p class="mb-1">{{ job.location }}</p>
   </div>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -7,7 +7,7 @@
   {% for j in jobs %}
   <tr>
     <td>{{ loop.index }}</td>
-    <td>{{ j.title }}</td>
+    <td><a href="{{ j.job_url }}" target="_blank" rel="noopener">{{ j.title }}</a></td>
     <td>{{ j.company }}</td>
     <td>{{ j.likes }}</td>
     <td>{{ j.dislikes }}</td>

--- a/app/templates/swipe.html
+++ b/app/templates/swipe.html
@@ -4,7 +4,7 @@
 <h1 class="mb-4">Is this job a good fit?</h1>
 <div class="card mb-4 mx-auto job-card single">
   <div class="card-body d-flex flex-column">
-    <h2 class="card-title">{{ job.title }}</h2>
+    <h2 class="card-title"><a href="{{ job.job_url }}" target="_blank" rel="noopener">{{ job.title }}</a></h2>
     <p class="card-subtitle mb-2 text-muted">{{ job.company }}</p>
     <p class="mb-1">{{ job.location }}</p>
     <p class="mb-1">{{ job.site }}</p>


### PR DESCRIPTION
## Summary
- link to the original posting whenever a job is shown
- make job titles clickable in swipe, reject, and stats views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bba5778a88330a0966a6d602e7881