### PR TITLE
Enable full descriptions from LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,6 @@ docker compose up
    Feedback is stored in a SQLite database inside the container to help train a future matching model.
 
 The application uses [JobSpy](https://pypi.org/project/python-jobspy/) to scrape
-job boards and FastAPI for the web interface.
+job boards and FastAPI for the web interface. If LinkedIn descriptions are
+missing, the scraper now passes `linkedin_fetch_description=True` which visits
+each LinkedIn job page to pull the full text.

--- a/app/main.py
+++ b/app/main.py
@@ -190,6 +190,7 @@ def fetch_jobs_task(search_term: str, location: str, sites: List[str]) -> None:
                 results_wanted=50,
                 hours_old=168,
                 description_format="html",
+                linkedin_fetch_description=site == "linkedin",
                 verbose=1,
             )
             jobs.append(df)

--- a/job_search_ohio.py
+++ b/job_search_ohio.py
@@ -42,6 +42,7 @@ def main():
                 results_wanted=50,           # number of results per site
                 hours_old=168,               # only listings posted in the last 7 days
                 description_format="markdown",
+                linkedin_fetch_description=site == "linkedin",
                 verbose=1
             )
             jobs.append(data)


### PR DESCRIPTION
## Summary
- fetch full descriptions from LinkedIn job posts by passing `linkedin_fetch_description=True`
- document the new behaviour in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bbd8b1c0c8330aef4d7c77bd6fe3b