### PR TITLE
Add job cleanup management page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,7 @@
         <a class="nav-link" href="/">Search</a>
         <a class="nav-link" href="/swipe">Swipe</a>
         <a class="nav-link" href="/stats">Stats</a>
+        <a class="nav-link" href="/manage">Manage</a>
       </div>
     </div>
   </nav>

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Manage Jobs{% endblock %}
+{% block content %}
+<h1 class="mb-4">Manage Jobs</h1>
+<form method="post" action="/cleanup" onsubmit="return confirm('Delete matching jobs?');">
+  <button class="btn btn-danger" type="submit">Clean Database</button>
+</form>
+{% if deleted is not none %}
+<p class="mt-3">{{ deleted }} jobs deleted.</p>
+{% endif %}
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -169,3 +169,57 @@ def test_fetch_jobs_task(main, monkeypatch):
     assert count == 2
     assert main.progress_logs[-1] == "Done"
 
+
+def test_cleanup_jobs(main):
+    main.init_db()
+    df = pd.DataFrame([
+        {
+            "site": "t",
+            "title": "Dev",
+            "company": "Comp",
+            "location": "L",
+            "date_posted": "d",
+            "description": "",
+            "interval": "year",
+            "min_amount": 1,
+            "max_amount": 2,
+            "currency": "USD",
+            "job_url": "http://example.com/1",
+        },
+        {
+            "site": "t",
+            "title": "Dev",
+            "company": "Comp",
+            "location": "L",
+            "date_posted": "d",
+            "description": "desc",
+            "interval": "year",
+            "min_amount": 1,
+            "max_amount": 2,
+            "currency": "USD",
+            "job_url": "http://example.com/2",
+        },
+        {
+            "site": "t",
+            "title": "Dev",
+            "company": "Comp",
+            "location": "L",
+            "date_posted": "d",
+            "description": "desc2",
+            "interval": "year",
+            "min_amount": 1,
+            "max_amount": 2,
+            "currency": "USD",
+            "job_url": "http://example.com/3",
+        },
+    ])
+    main.save_jobs(df)
+    deleted = main.cleanup_jobs()
+    conn = sqlite3.connect(main.DATABASE)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM jobs")
+    count = cur.fetchone()[0]
+    conn.close()
+    assert deleted == 2
+    assert count == 1
+


### PR DESCRIPTION
## Summary
- add function and route to clean up jobs without descriptions and remove duplicate jobs
- expose cleanup via new Manage page and nav link
- test cleanup behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbfea58a4833090e636475854e5be