### PR TITLE
Add aggregate stats on jobs

### DIFF
--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -14,4 +14,25 @@
   </tr>
   {% endfor %}
 </table>
+
+<h2 class="mt-5">Aggregate Stats</h2>
+<p>Total jobs stored: {{ stats.total_jobs }}</p>
+
+<h3>Roles per Source</h3>
+<table class="table table-sm">
+  <tr><th>Site</th><th>Count</th></tr>
+  {% for site, count in stats.by_site.items() %}
+  <tr><td>{{ site }}</td><td>{{ count }}</td></tr>
+  {% endfor %}
+</table>
+
+<h3>Posts by Date</h3>
+<table class="table table-sm">
+  <tr><th>Date</th><th>Count</th></tr>
+  {% for date, count in stats.by_date.items() %}
+  <tr><td>{{ date }}</td><td>{{ count }}</td></tr>
+  {% endfor %}
+</table>
+
+<p>Average salary (where provided): {{ format_salary(stats.avg_min_pay, stats.avg_max_pay, 'USD') }}</p>
 {% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -223,3 +223,55 @@ def test_cleanup_jobs(main):
     assert deleted == 2
     assert count == 1
 
+
+def test_aggregate_job_stats(main):
+    main.init_db()
+    df = pd.DataFrame([
+        {
+            "site": "a",
+            "title": "T1",
+            "company": "C1",
+            "location": "L",
+            "date_posted": "2024-01-01",
+            "description": "d",
+            "interval": "year",
+            "min_amount": 100,
+            "max_amount": 200,
+            "currency": "USD",
+            "job_url": "http://x.com/1",
+        },
+        {
+            "site": "b",
+            "title": "T2",
+            "company": "C2",
+            "location": "L",
+            "date_posted": "2024-01-02",
+            "description": "d2",
+            "interval": "year",
+            "min_amount": 200,
+            "max_amount": 300,
+            "currency": "USD",
+            "job_url": "http://x.com/2",
+        },
+        {
+            "site": "a",
+            "title": "T3",
+            "company": "C3",
+            "location": "L",
+            "date_posted": "2024-01-01",
+            "description": "d3",
+            "interval": "year",
+            "min_amount": None,
+            "max_amount": None,
+            "currency": None,
+            "job_url": "http://x.com/3",
+        },
+    ])
+    main.save_jobs(df)
+    stats = main.aggregate_job_stats()
+    assert stats["total_jobs"] == 3
+    assert stats["by_site"] == {"a": 2, "b": 1}
+    assert stats["by_date"] == {"2024-01-01": 2, "2024-01-02": 1}
+    assert stats["avg_min_pay"] == pytest.approx(150)
+    assert stats["avg_max_pay"] == pytest.approx(250)
+


### PR DESCRIPTION
## Summary
- compute aggregate job stats
- display aggregated statistics on stats page
- test aggregate_job_stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc2b396748330afbb4425778c549c