### PR TITLE
Show logs during job fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ docker compose up
    using the green ✓ button to mark a good match or the red ✖ button to
    reject it. When rejecting a job you will be asked to provide a reason.
    Feedback is stored in a SQLite database inside the container to help train a future matching model.
+   If any job boards fail to fetch (for example due to network restrictions) the
+   progress screen now shows detailed logs so you can see which sources were skipped.
 
 The application uses [JobSpy](https://pypi.org/project/python-jobspy/) to scrape
 job boards and FastAPI for the web interface. If LinkedIn descriptions are

--- a/app/templates/progress.html
+++ b/app/templates/progress.html
@@ -2,6 +2,7 @@
 {% block title %}Fetching Jobs{% endblock %}
 {% block content %}
 <h1 class="mb-3">Fetching jobs...</h1>
+<pre id="logs" class="bg-light p-2" style="max-height: 300px; overflow-y: auto;"></pre>
 <div class="d-flex justify-content-center my-4">
   <div class="spinner-border" role="status">
     <span class="visually-hidden">Loading...</span>
@@ -11,6 +12,7 @@
 async function poll() {
   const r = await fetch('/progress');
   const data = await r.json();
+  document.getElementById('logs').innerHTML = data.logs.join('\n');
   if (data.done) {
     window.location.href = '/swipe';
   } else {


### PR DESCRIPTION
## Summary
- display progress logs while jobs are fetched
- mention the new logs in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc4bb32748330b4ca11206aabe0c2