### PR TITLE
Add Ollama integration for job summaries

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -5,6 +5,8 @@ body { font-family: Arial, sans-serif; background: #f8f9fa; color: #333; padding
 .job-card { flex: 1; border: 1px solid #ccc; padding: 1rem; background: #fafafa; border-radius: 0.25rem; }
 .job-card.single { max-width: 800px; margin: auto; }
 .job-desc { max-height: none; overflow-y: visible; }
+.ai-summary { background: #eef; padding: 0.5rem; border-radius: 0.25rem; }
+.original-desc { border-top: 1px dashed #ccc; padding-top: 0.5rem; }
 .swipe-buttons { margin-top: 1rem; display: flex; gap: 1rem; justify-content: center; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(255,255,255,0.9); padding: 0.5rem 1rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
 .good { background: #4caf50; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; cursor: pointer; }
 .bad { background: #f44336; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; text-decoration: none; display: inline-block; text-align: center; }

--- a/app/templates/swipe.html
+++ b/app/templates/swipe.html
@@ -11,8 +11,11 @@
     {% if job.min_amount %}
     <p class="mb-1">{{ format_salary(job.min_amount, job.max_amount, job.currency) }}</p>
     {% endif %}
+    {% if job.summary %}
+    <div class="ai-summary mb-3">{{ job.summary | safe }}</div>
+    {% endif %}
     {% if job.description %}
-    <div class="job-desc flex-grow-1">{{ job.description | safe }}</div>
+    <div class="original-desc job-desc flex-grow-1">{{ job.description | safe }}</div>
     {% else %}
     <p>No description available.</p>
     {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ fastapi
 uvicorn
 jinja2
 python-multipart
+requests
 pytest


### PR DESCRIPTION
## Summary
- integrate Ollama via `OLLAMA_BASE_URL` and `OLLAMA_MODEL`
- download model and generate summaries & embeddings
- store embeddings and summaries in new tables
- show AI generated summary ahead of original description
- style summary section
- add requests dependency

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf2af6c0883309982cff50f8ebb13