### PR TITLE
Allow separate models for embeddings and rephrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ services:
     environment:
       - DATABASE=/config/jobs.db
       - OLLAMA_BASE_URL=http://ollama:11434
+      # Optional: use different models for embeddings and rephrasing
+      - OLLAMA_EMBED_MODEL=llama3
+      - OLLAMA_REPHRASE_MODEL=llama3
     volumes:
       - ./data:/config
 ```
+
+`OLLAMA_EMBED_MODEL` and `OLLAMA_REPHRASE_MODEL` default to the value of
+`OLLAMA_MODEL` (or `llama3` if unset) so existing setups continue to work.
 
 Then run:
 


### PR DESCRIPTION
## Summary
- add `OLLAMA_EMBED_MODEL` and `OLLAMA_REPHRASE_MODEL` env vars
- document new variables in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf6d32fd883309f865a3d536a2d21