### PR TITLE
Add AI data regeneration option

### DIFF
--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -5,6 +5,9 @@
 <form method="post" action="/cleanup" onsubmit="return confirm('Delete matching jobs?');">
   <button class="btn btn-danger" type="submit">Clean Database</button>
 </form>
+<form class="mt-3" method="post" action="/reprocess" onsubmit="return confirm('Recreate all summaries and embeddings?');">
+  <button class="btn btn-warning" type="submit">Recreate AI Data</button>
+</form>
 {% if deleted is not none %}
 <p class="mt-3">{{ deleted }} jobs deleted.</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- allow passing context size options to Ollama API to avoid truncation
- add background task to delete old summaries and embeddings
- expose `/reprocess` endpoint and button in *Manage* page
- test regeneration logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfd319ae88330aa32bccb270fe8d1