### PR TITLE
Improve summary display and AI data management

### DIFF
--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -5,8 +5,11 @@
 <form method="post" action="/cleanup" onsubmit="return confirm('Delete matching jobs?');">
   <button class="btn btn-danger" type="submit">Clean Database</button>
 </form>
-<form class="mt-3" method="post" action="/reprocess" onsubmit="return confirm('Recreate all summaries and embeddings?');">
-  <button class="btn btn-warning" type="submit">Recreate AI Data</button>
+<form class="mt-3" method="post" action="/reprocess" onsubmit="return confirm('Generate AI data for missing roles?');">
+  <button class="btn btn-warning" type="submit">Generate Missing AI Data</button>
+</form>
+<form class="mt-3" method="post" action="/delete_ai" onsubmit="return confirm('Delete all summaries and embeddings?');">
+  <button class="btn btn-danger" type="submit">Delete AI Data</button>
 </form>
 {% if deleted is not none %}
 <p class="mt-3">{{ deleted }} jobs deleted.</p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ uvicorn
 jinja2
 python-multipart
 requests
+markdown
 pytest


### PR DESCRIPTION
## Summary
- convert AI summaries from markdown to HTML
- add tasks to clear AI data and to generate missing AI data
- expose new buttons on the manage page
- update tests for the new behaviour
- add markdown dependency
- store markdown summaries and raise context length

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c005013f883308aba0a27f0bc0b85