### PR TITLE
Fix bullet formatting in summaries

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,17 +44,18 @@ Rewrite the following job description into concise Markdown without preamble.
 Omit any sections that cannot be filled from the text. Use this structure:
 
 ---
-**Company:** short overview
-
 **Technical Requirements**
+
 - item one
 - item two
 
 **Soft Skills**
+
 - item one
 - item two
 
 **Description**
+
 A short paragraph summarizing the role.
 ---
 
@@ -121,6 +122,12 @@ def render_markdown(text: str) -> str:
         return ""
     lines = [ln for ln in text.splitlines() if ln.strip() != "---"]
     cleaned = "\n".join(lines)
+    fixed = []
+    for ln in cleaned.splitlines():
+        if ln.lstrip().startswith("-") and fixed and fixed[-1].strip():
+            fixed.append("")
+        fixed.append(ln)
+    cleaned = "\n".join(fixed)
     return markdown(cleaned)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -282,6 +282,12 @@ def test_render_markdown(main):
     assert "---" not in html
 
 
+def test_render_markdown_lists(main):
+    text = "**Technical Requirements**\n- a\n- b"
+    html = main.render_markdown(text)
+    assert html.count("<li>") == 2
+
+
 def test_clear_ai_data_and_reprocess_tasks(main, monkeypatch):
     main.init_db()
     df = pd.DataFrame([


### PR DESCRIPTION
## Summary
- improve the prompt template for AI summaries
- ensure markdown renderer inserts blank line before list items so `-` bullets show up
- test bullet list rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c038a3dc48330b63d314ba4dc4c44