### PR TITLE
Refactor app into modules and add ML predictions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,9 @@
+import os
+
+DATABASE = os.environ.get("DATABASE", "jobs.db")
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL")
+_default_model = os.environ.get("OLLAMA_MODEL", "llama3")
+OLLAMA_EMBED_MODEL = os.environ.get("OLLAMA_EMBED_MODEL", _default_model)
+OLLAMA_REPHRASE_MODEL = os.environ.get("OLLAMA_REPHRASE_MODEL", _default_model)
+OLLAMA_ENABLED = bool(OLLAMA_BASE_URL)
+BUILD_NUMBER = os.environ.get("GITHUB_RUN_NUMBER") or os.environ.get("BUILD_NUMBER", "dev")

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,263 @@
+import json
+import sqlite3
+import time
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from . import main as app_main
+from .ai import OLLAMA_ENABLED, process_all_jobs, render_markdown
+from .model import train_model, _model
+
+
+def init_db() -> None:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            site TEXT,
+            title TEXT,
+            company TEXT,
+            location TEXT,
+            date_posted TEXT,
+            description TEXT,
+            interval TEXT,
+            min_amount REAL,
+            max_amount REAL,
+            currency TEXT,
+            job_url TEXT UNIQUE,
+            rating_count INTEGER DEFAULT 0
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feedback(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id INTEGER,
+            liked INTEGER,
+            reason TEXT,
+            rated_at INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS embeddings(
+            job_id INTEGER PRIMARY KEY,
+            embedding TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS summaries(
+            job_id INTEGER PRIMARY KEY,
+            summary TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_jobs(df: pd.DataFrame) -> None:
+    if df.empty:
+        return
+    cols = {
+        "site": None,
+        "title": None,
+        "company": None,
+        "location": None,
+        "date_posted": None,
+        "description": None,
+        "interval": None,
+        "min_amount": None,
+        "max_amount": None,
+        "currency": None,
+        "job_url": None,
+    }
+    df = df.loc[:, df.columns.intersection(cols.keys())]
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    for _, row in df.iterrows():
+        values = tuple(row.get(c) for c in cols)
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO jobs(site,title,company,location,date_posted,description,interval,min_amount,max_amount,currency,job_url)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            """,
+            values,
+        )
+    conn.commit()
+    conn.close()
+    if OLLAMA_ENABLED:
+        process_all_jobs()
+
+
+def get_random_job() -> Optional[Dict]:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT j.*, s.summary FROM jobs j
+        LEFT JOIN summaries s ON j.id = s.job_id
+        ORDER BY rating_count ASC, RANDOM() LIMIT 1
+        """
+    )
+    row = cur.fetchone()
+    columns = [c[0] for c in cur.description]
+    conn.close()
+    if row:
+        job = dict(zip(columns, row))
+        if job.get("summary"):
+            job["summary"] = render_markdown(job["summary"])
+        return job
+    return None
+
+
+def get_job(job_id: int) -> Optional[Dict]:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT j.*, s.summary FROM jobs j
+        LEFT JOIN summaries s ON j.id = s.job_id
+        WHERE j.id=?
+        """,
+        (job_id,),
+    )
+    row = cur.fetchone()
+    columns = [c[0] for c in cur.description]
+    conn.close()
+    if row:
+        job = dict(zip(columns, row))
+        if job.get("summary"):
+            job["summary"] = render_markdown(job["summary"])
+        return job
+    return None
+
+
+def list_jobs_by_feedback() -> List[Dict]:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT j.*, 
+               COALESCE(SUM(CASE WHEN f.liked=1 THEN 1 ELSE 0 END), 0) AS likes,
+               COALESCE(SUM(CASE WHEN f.liked=0 THEN 1 ELSE 0 END), 0) AS dislikes,
+               CASE WHEN s.job_id IS NOT NULL THEN 1 ELSE 0 END AS has_summary,
+               CASE WHEN e.job_id IS NOT NULL THEN 1 ELSE 0 END AS has_embedding
+        FROM jobs j
+        LEFT JOIN feedback f ON j.id = f.job_id
+        LEFT JOIN summaries s ON j.id = s.job_id
+        LEFT JOIN embeddings e ON j.id = e.job_id
+        GROUP BY j.id
+        ORDER BY likes DESC
+        """
+    )
+    rows = cur.fetchall()
+    columns = [c[0] for c in cur.description]
+    conn.close()
+    return [dict(zip(columns, r)) for r in rows]
+
+
+def aggregate_job_stats() -> Dict:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+
+    cur.execute("SELECT COUNT(*) FROM jobs")
+    total_jobs = cur.fetchone()[0]
+
+    cur.execute("SELECT site, COUNT(*) FROM jobs GROUP BY site")
+    by_site = {site: count for site, count in cur.fetchall()}
+
+    cur.execute("SELECT date_posted, COUNT(*) FROM jobs GROUP BY date_posted")
+    by_date = {date: count for date, count in cur.fetchall()}
+
+    cur.execute(
+        "SELECT AVG(min_amount), AVG(max_amount) FROM jobs WHERE min_amount IS NOT NULL AND max_amount IS NOT NULL"
+    )
+    avg_min, avg_max = cur.fetchone()
+
+    cur.execute("SELECT COUNT(*) FROM summaries")
+    summaries_count = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM embeddings")
+    embeddings_count = cur.fetchone()[0]
+
+    conn.close()
+    return {
+        "total_jobs": total_jobs,
+        "by_site": by_site,
+        "by_date": by_date,
+        "avg_min_pay": avg_min or 0,
+        "avg_max_pay": avg_max or 0,
+        "jobs_with_summaries": summaries_count,
+        "jobs_with_embeddings": embeddings_count,
+    }
+
+
+def increment_rating_count(job_id: int) -> None:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute("SELECT rating_count FROM jobs WHERE id=?", (job_id,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return
+    count = row[0] + 1
+    cur.execute("UPDATE jobs SET rating_count=? WHERE id=?", (count, job_id))
+    conn.commit()
+    conn.close()
+
+
+def record_feedback(job_id: int, liked: bool, reason: Optional[str]) -> None:
+    increment_rating_count(job_id)
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO feedback(job_id, liked, reason, rated_at) VALUES(?,?,?,?)",
+        (job_id, int(liked), reason, int(time.time())),
+    )
+    conn.commit()
+    conn.close()
+
+    retrain = False
+    if _model is not None:
+        conn = sqlite3.connect(app_main.DATABASE)
+        cur = conn.cursor()
+        cur.execute("SELECT embedding FROM embeddings WHERE job_id=?", (job_id,))
+        row = cur.fetchone()
+        conn.close()
+        if row:
+            emb = json.loads(row[0])
+            pred = int(_model.predict([emb])[0])
+            retrain = pred != int(liked)
+    else:
+        retrain = True
+
+    if retrain:
+        train_model()
+
+
+def cleanup_jobs() -> int:
+    conn = sqlite3.connect(app_main.DATABASE)
+    cur = conn.cursor()
+
+    cur.execute("DELETE FROM jobs WHERE description IS NULL OR description = ''")
+    deleted_missing = cur.rowcount
+
+    cur.execute(
+        """
+        DELETE FROM jobs
+        WHERE id NOT IN (
+            SELECT MIN(id) FROM jobs GROUP BY title, company
+        )
+        """
+    )
+    deleted_dupes = cur.rowcount
+    conn.commit()
+    conn.close()
+    return deleted_missing + deleted_dupes

--- a/app/main.py
+++ b/app/main.py
@@ -1,32 +1,43 @@
 import os
 import sqlite3
 import time
-import json
 from typing import List, Dict, Optional
-
-from markdown import markdown
 
 import logging
 from collections import deque
 from threading import Thread
 
 import pandas as pd
-import requests
 from fastapi import FastAPI, Form, Request, BackgroundTasks
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from jobspy import scrape_jobs
 
-DATABASE = os.environ.get("DATABASE", "jobs.db")
-OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL")
-
-# Allow separate models for embeddings and rephrasing while keeping backwards
-# compatibility with the original `OLLAMA_MODEL` variable.
-_default_model = os.environ.get("OLLAMA_MODEL", "llama3")
-OLLAMA_EMBED_MODEL = os.environ.get("OLLAMA_EMBED_MODEL", _default_model)
-OLLAMA_REPHRASE_MODEL = os.environ.get("OLLAMA_REPHRASE_MODEL", _default_model)
-OLLAMA_ENABLED = bool(OLLAMA_BASE_URL)
+from .config import (
+    DATABASE,
+    OLLAMA_ENABLED,
+    BUILD_NUMBER,
+)
+from .db import (
+    init_db,
+    save_jobs,
+    get_random_job,
+    get_job,
+    list_jobs_by_feedback,
+    aggregate_job_stats,
+    increment_rating_count,
+    record_feedback,
+    cleanup_jobs,
+)
+from .ai import (
+    ensure_model_downloaded,
+    embed_text,
+    generate_summary,
+    render_markdown,
+    process_all_jobs,
+)
+from .model import train_model, predict_unrated
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
@@ -64,103 +75,6 @@ Job posting:
 '''
 
 
-def ensure_model_downloaded() -> None:
-    if not OLLAMA_ENABLED:
-        return
-    for model in {OLLAMA_EMBED_MODEL, OLLAMA_REPHRASE_MODEL}:
-        try:
-            requests.post(f"{OLLAMA_BASE_URL}/api/pull", json={"name": model}, timeout=120)
-        except Exception as exc:
-            logger.info(f"Failed to pull model {model}: {exc}")
-
-
-def embed_text(text: str) -> List[float]:
-    if not OLLAMA_ENABLED:
-        return []
-    try:
-        r = requests.post(
-            f"{OLLAMA_BASE_URL}/api/embeddings",
-            json={
-                "model": OLLAMA_EMBED_MODEL,
-                "prompt": text,
-                "options": {"num_ctx": 4096},
-            },
-            timeout=120,
-        )
-        r.raise_for_status()
-        return r.json().get("embedding", [])
-    except Exception as exc:
-        logger.info(f"Embedding failed: {exc}")
-        return []
-
-
-def generate_summary(text: str) -> str:
-    if not OLLAMA_ENABLED:
-        return ""
-    prompt = REWRITE_PROMPT_TEMPLATE.format(description=text)
-    try:
-        r = requests.post(
-            f"{OLLAMA_BASE_URL}/api/generate",
-            json={
-                "model": OLLAMA_REPHRASE_MODEL,
-                "prompt": prompt,
-                "stream": False,
-                "options": {"num_ctx": 8192},
-            },
-            timeout=120,
-        )
-        r.raise_for_status()
-        return r.json().get("response", "")
-    except Exception as exc:
-        logger.info(f"Summary generation failed: {exc}")
-        return ""
-
-
-def render_markdown(text: str) -> str:
-    """Convert Markdown to HTML after stripping '---' delimiters."""
-    if not text:
-        return ""
-    lines = [ln for ln in text.splitlines() if ln.strip() != "---"]
-    cleaned = "\n".join(lines)
-    fixed = []
-    for ln in cleaned.splitlines():
-        if ln.lstrip().startswith("-") and fixed and fixed[-1].strip():
-            fixed.append("")
-        fixed.append(ln)
-    cleaned = "\n".join(fixed)
-    return markdown(cleaned)
-
-
-def process_all_jobs() -> None:
-    if not OLLAMA_ENABLED:
-        return
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute("SELECT id, description FROM jobs")
-    rows = cur.fetchall()
-    for job_id, desc in rows:
-        if not desc:
-            continue
-        cur.execute("SELECT 1 FROM summaries WHERE job_id=?", (job_id,))
-        have_sum = cur.fetchone()
-        cur.execute("SELECT 1 FROM embeddings WHERE job_id=?", (job_id,))
-        have_emb = cur.fetchone()
-        if have_sum and have_emb:
-            continue
-        summary = generate_summary(desc) if not have_sum else None
-        embedding = embed_text(desc) if not have_emb else None
-        if summary is not None:
-            cur.execute(
-                "INSERT OR IGNORE INTO summaries(job_id, summary) VALUES(?, ?)",
-                (job_id, summary),
-            )
-        if embedding is not None:
-            cur.execute(
-                "INSERT OR IGNORE INTO embeddings(job_id, embedding) VALUES(?, ?)",
-                (job_id, json.dumps(embedding)),
-            )
-        conn.commit()
-    conn.close()
 
 
 def format_salary(min_amount: float, max_amount: float, currency: str) -> str:
@@ -229,225 +143,6 @@ def log_progress(message: str) -> None:
 
 
 
-def init_db() -> None:
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS jobs(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            site TEXT,
-            title TEXT,
-            company TEXT,
-            location TEXT,
-            date_posted TEXT,
-            description TEXT,
-            interval TEXT,
-            min_amount REAL,
-            max_amount REAL,
-            currency TEXT,
-            job_url TEXT UNIQUE,
-            rating_count INTEGER DEFAULT 0
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS feedback(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            job_id INTEGER,
-            liked INTEGER,
-            reason TEXT,
-            rated_at INTEGER
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS embeddings(
-            job_id INTEGER PRIMARY KEY,
-            embedding TEXT
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS summaries(
-            job_id INTEGER PRIMARY KEY,
-            summary TEXT
-        )
-        """
-    )
-    conn.commit()
-    conn.close()
-
-
-def save_jobs(df: pd.DataFrame) -> None:
-    if df.empty:
-        return
-    cols = {
-        "site": None,
-        "title": None,
-        "company": None,
-        "location": None,
-        "date_posted": None,
-        "description": None,
-        "interval": None,
-        "min_amount": None,
-        "max_amount": None,
-        "currency": None,
-        "job_url": None,
-    }
-    # Keep only the columns we know about
-    df = df.loc[:, df.columns.intersection(cols.keys())]
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    for _, row in df.iterrows():
-        values = tuple(row.get(c) for c in cols)
-        cur.execute(
-            """
-            INSERT OR IGNORE INTO jobs(site,title,company,location,date_posted,description,interval,min_amount,max_amount,currency,job_url)
-            VALUES(?,?,?,?,?,?,?,?,?,?,?)
-            """,
-            values,
-        )
-    conn.commit()
-    conn.close()
-    if OLLAMA_ENABLED:
-        process_all_jobs()
-
-
-def get_random_job() -> Optional[Dict]:
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT j.*, s.summary FROM jobs j
-        LEFT JOIN summaries s ON j.id = s.job_id
-        ORDER BY rating_count ASC, RANDOM() LIMIT 1
-        """
-    )
-    row = cur.fetchone()
-    columns = [c[0] for c in cur.description]
-    conn.close()
-    if row:
-        job = dict(zip(columns, row))
-        if job.get("summary"):
-            job["summary"] = render_markdown(job["summary"])
-        return job
-    return None
-
-
-def get_job(job_id: int) -> Optional[Dict]:
-    """Return a job by id including any summary."""
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT j.*, s.summary FROM jobs j
-        LEFT JOIN summaries s ON j.id = s.job_id
-        WHERE j.id=?
-        """,
-        (job_id,),
-    )
-    row = cur.fetchone()
-    columns = [c[0] for c in cur.description]
-    conn.close()
-    if row:
-        job = dict(zip(columns, row))
-        if job.get("summary"):
-            job["summary"] = render_markdown(job["summary"])
-        return job
-    return None
-
-
-def list_jobs_by_feedback() -> List[Dict]:
-    """Return jobs ordered by number of positive ratings."""
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT j.*,
-               COALESCE(SUM(CASE WHEN f.liked=1 THEN 1 ELSE 0 END), 0) AS likes,
-               COALESCE(SUM(CASE WHEN f.liked=0 THEN 1 ELSE 0 END), 0) AS dislikes,
-               CASE WHEN s.job_id IS NOT NULL THEN 1 ELSE 0 END AS has_summary,
-               CASE WHEN e.job_id IS NOT NULL THEN 1 ELSE 0 END AS has_embedding
-        FROM jobs j
-        LEFT JOIN feedback f ON j.id = f.job_id
-        LEFT JOIN summaries s ON j.id = s.job_id
-        LEFT JOIN embeddings e ON j.id = e.job_id
-        GROUP BY j.id
-        ORDER BY likes DESC
-        """
-    )
-    rows = cur.fetchall()
-    columns = [c[0] for c in cur.description]
-    conn.close()
-    return [dict(zip(columns, r)) for r in rows]
-
-
-def aggregate_job_stats() -> Dict:
-    """Return aggregate statistics about the stored jobs."""
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-
-    cur.execute("SELECT COUNT(*) FROM jobs")
-    total_jobs = cur.fetchone()[0]
-
-    cur.execute("SELECT site, COUNT(*) FROM jobs GROUP BY site")
-    by_site = {site: count for site, count in cur.fetchall()}
-
-    cur.execute("SELECT date_posted, COUNT(*) FROM jobs GROUP BY date_posted")
-    by_date = {date: count for date, count in cur.fetchall()}
-
-    cur.execute(
-        "SELECT AVG(min_amount), AVG(max_amount) FROM jobs WHERE min_amount IS NOT NULL AND max_amount IS NOT NULL"
-    )
-    avg_min, avg_max = cur.fetchone()
-
-    cur.execute("SELECT COUNT(*) FROM summaries")
-    summaries_count = cur.fetchone()[0]
-    cur.execute("SELECT COUNT(*) FROM embeddings")
-    embeddings_count = cur.fetchone()[0]
-
-    conn.close()
-    return {
-        "total_jobs": total_jobs,
-        "by_site": by_site,
-        "by_date": by_date,
-        "avg_min_pay": avg_min or 0,
-        "avg_max_pay": avg_max or 0,
-        "jobs_with_summaries": summaries_count,
-        "jobs_with_embeddings": embeddings_count,
-    }
-
-
-def increment_rating_count(job_id: int) -> None:
-    """Increment the rating count for a job."""
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute("SELECT rating_count FROM jobs WHERE id=?", (job_id,))
-    row = cur.fetchone()
-    if not row:
-        conn.close()
-        return
-    count = row[0] + 1
-    cur.execute("UPDATE jobs SET rating_count=? WHERE id=?", (count, job_id))
-    conn.commit()
-    conn.close()
-
-
-def record_feedback(job_id: int, liked: bool, reason: Optional[str]) -> None:
-    """Store feedback and increment rating count."""
-    increment_rating_count(job_id)
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO feedback(job_id, liked, reason, rated_at) VALUES(?,?,?,?)",
-        (job_id, int(liked), reason, int(time.time())),
-    )
-    conn.commit()
-    conn.close()
 
 
 def fetch_jobs_task(search_term: str, location: str, sites: List[str]) -> None:
@@ -485,10 +180,12 @@ def fetch_jobs_task(search_term: str, location: str, sites: List[str]) -> None:
 @app.on_event("startup")
 def on_startup() -> None:
     init_db()
+    train_model()
     if OLLAMA_ENABLED:
         def worker():
             ensure_model_downloaded()
             process_all_jobs()
+            train_model()
 
         Thread(target=worker, daemon=True).start()
 
@@ -551,31 +248,13 @@ def feedback(job_id: int = Form(...), liked: int = Form(...), reason: str = Form
 def stats(request: Request):
     jobs = list_jobs_by_feedback()
     agg = aggregate_job_stats()
+    predictions = predict_unrated()
     return templates.TemplateResponse(
-        "stats.html", {"request": request, "jobs": jobs, "stats": agg}
+        "stats.html",
+        {"request": request, "jobs": jobs, "stats": agg, "predictions": predictions},
     )
 
 
-def cleanup_jobs() -> int:
-    """Delete jobs without a description and remove duplicate title/company entries."""
-    conn = sqlite3.connect(DATABASE)
-    cur = conn.cursor()
-
-    cur.execute("DELETE FROM jobs WHERE description IS NULL OR description = ''")
-    deleted_missing = cur.rowcount
-
-    cur.execute(
-        """
-        DELETE FROM jobs
-        WHERE id NOT IN (
-            SELECT MIN(id) FROM jobs GROUP BY title, company
-        )
-        """
-    )
-    deleted_dupes = cur.rowcount
-    conn.commit()
-    conn.close()
-    return deleted_missing + deleted_dupes
 
 
 @app.get("/manage", response_class=HTMLResponse)

--- a/app/model.py
+++ b/app/model.py
@@ -1,0 +1,58 @@
+import json
+import sqlite3
+from typing import Dict, List
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from .config import DATABASE
+
+_model: LogisticRegression | None = None
+
+
+def train_model() -> None:
+    """Train a logistic regression model from feedback and embeddings."""
+    global _model
+    conn = sqlite3.connect(DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT f.liked, e.embedding
+        FROM feedback f
+        JOIN embeddings e ON f.job_id = e.job_id
+        """
+    )
+    rows = cur.fetchall()
+    conn.close()
+    if not rows:
+        _model = None
+        return
+    X = np.array([json.loads(r[1]) for r in rows])
+    y = np.array([r[0] for r in rows])
+    _model = LogisticRegression(max_iter=1000)
+    _model.fit(X, y)
+
+
+def predict_unrated() -> List[Dict]:
+    """Return predictions for unrated jobs sorted by confidence."""
+    if _model is None:
+        return []
+    conn = sqlite3.connect(DATABASE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT j.id, j.title, j.company, e.embedding
+        FROM jobs j
+        JOIN embeddings e ON j.id = e.job_id
+        WHERE j.id NOT IN (SELECT job_id FROM feedback)
+        """
+    )
+    rows = cur.fetchall()
+    conn.close()
+    results = []
+    for job_id, title, company, emb in rows:
+        vec = json.loads(emb)
+        prob = float(_model.predict_proba([vec])[0, 1])
+        results.append({"id": job_id, "title": title, "company": company, "confidence": prob})
+    results.sort(key=lambda x: x["confidence"], reverse=True)
+    return results

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,6 +1,6 @@
 body { font-family: Arial, sans-serif; background: #f8f9fa; color: #333; padding-bottom: 80px; }
 .nav { margin-bottom: 1rem; }
-.container { max-width: 900px; margin: auto; background: #fff; padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); border-radius: 0.25rem; }
+.container { max-width: 1200px; margin: auto; background: #fff; padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.1); border-radius: 0.25rem; }
 .job-grid { display: flex; gap: 1rem; }
 .job-card { flex: 1; border: 1px solid #ccc; padding: 1rem; background: #fafafa; border-radius: 0.25rem; }
 .job-card.single { max-width: 800px; margin: auto; }
@@ -8,8 +8,8 @@ body { font-family: Arial, sans-serif; background: #f8f9fa; color: #333; padding
 .ai-summary { background: #eef; padding: 0.5rem; border-radius: 0.25rem; }
 .original-desc { border-top: 1px dashed #ccc; padding-top: 0.5rem; }
 .swipe-buttons { margin-top: 1rem; display: flex; gap: 1rem; justify-content: center; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(255,255,255,0.9); padding: 0.5rem 1rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
-.good { background: #4caf50; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; cursor: pointer; }
-.bad { background: #f44336; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 1.2rem; text-decoration: none; display: inline-block; text-align: center; }
+.good { background: #4caf50; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 3rem; cursor: pointer; }
+.bad { background: #f44336; color: #fff; border: none; padding: 0.5rem 1rem; font-size: 3rem; text-decoration: none; display: inline-block; text-align: center; }
 .bad:hover, .good:hover { opacity: 0.8; }
 pre { background: #f0f0f0; padding: 0.5rem; }
 .footer { text-align: center; margin-top: 2rem; padding-top: 0.5rem; font-size: 0.8rem; color: #888; border-top: 1px solid #eee; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
   <title>{% block title %}Job Ranker{% endblock %}</title>
 </head>
 <body class="d-flex flex-column min-vh-100">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <nav class="navbar navbar-expand navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="/">Job Ranker</a>
       <div class="navbar-nav">

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -52,4 +52,20 @@
 </table>
 
 <p>Average salary (where provided): {{ format_salary(stats.avg_min_pay, stats.avg_max_pay, 'USD') }}</p>
+
+<h2 class="mt-5">Predicted Matches</h2>
+{% if predictions %}
+<table class="table table-sm">
+  <tr><th>Title</th><th>Company</th><th>Confidence</th></tr>
+  {% for p in predictions %}
+  <tr>
+    <td><a href="/swipe?job_id={{ p.id }}">{{ p.title }}</a></td>
+    <td>{{ p.company }}</td>
+    <td>{{ '{:.0%}'.format(p.confidence) }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>No predictions available.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- break large `main.py` into modules (`db.py`, `ai.py`, `model.py`, `config.py`)
- widen layout container and enlarge swipe buttons
- keep navbar expanded on mobile
- show predicted job matches in stats page
- train a logistic regression model from feedback

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c064f6d9c8330b1f9f3851a7c0718