### PR TITLE
Add model performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ docker compose up
    Feedback is stored in a SQLite database inside the container to help train a future matching model.
    If any job boards fail to fetch (for example due to network restrictions) the
    progress screen now shows detailed logs so you can see which sources were skipped.
+   A statistics page summarizes stored jobs and reports model accuracy, precision and recall so you can track its performance.
 
 The application uses [JobSpy](https://pypi.org/project/python-jobspy/) to scrape
 job boards and FastAPI for the web interface. If LinkedIn descriptions are

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ from .ai import (
     render_markdown,
     process_all_jobs,
 )
-from .model import train_model, predict_unrated
+from .model import train_model, predict_unrated, evaluate_model
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
@@ -249,9 +249,16 @@ def stats(request: Request):
     jobs = list_jobs_by_feedback()
     agg = aggregate_job_stats()
     predictions = predict_unrated()
+    model_stats = evaluate_model()
     return templates.TemplateResponse(
         "stats.html",
-        {"request": request, "jobs": jobs, "stats": agg, "predictions": predictions},
+        {
+            "request": request,
+            "jobs": jobs,
+            "stats": agg,
+            "predictions": predictions,
+            "model_stats": model_stats,
+        },
     )
 
 

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -53,6 +53,21 @@
 
 <p>Average salary (where provided): {{ format_salary(stats.avg_min_pay, stats.avg_max_pay, 'USD') }}</p>
 
+<h2 class="mt-5">Model Performance</h2>
+{% if model_stats.total > 0 %}
+<ul>
+  <li>Accuracy: {{ '{:.0%}'.format(model_stats.accuracy) }}</li>
+  <li>Precision: {{ '{:.0%}'.format(model_stats.precision) }}</li>
+  <li>Recall: {{ '{:.0%}'.format(model_stats.recall) }}</li>
+  <li>True Positives: {{ model_stats.tp }}</li>
+  <li>True Negatives: {{ model_stats.tn }}</li>
+  <li>False Positives: {{ model_stats.fp }}</li>
+  <li>False Negatives: {{ model_stats.fn }}</li>
+</ul>
+{% else %}
+<p>No feedback available to evaluate the model.</p>
+{% endif %}
+
 <h2 class="mt-5">Predicted Matches</h2>
 {% if predictions %}
 <table class="table table-sm">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,7 @@ This project is a small job search and ranking tool built with **FastAPI**. Jobs
   - Summaries and embeddings are generated in `process_all_jobs`.
 - **Client UI**
   - HTML templates render pages for searching, swiping, viewing stats and managing stored jobs. Styling lives in `app/static/style.css`.
+  - The stats page also shows model performance including accuracy, precision, recall and counts of false/true positives and negatives.
 - **Tests** – under `tests/` using `pytest` to cover database operations and job fetching logic.
 - **Docker** – `Dockerfile` and `build.sh` build a container image. GitHub Actions automatically build and push on merges to `main`.
 


### PR DESCRIPTION
## Summary
- show prediction accuracy on stats page
- support evaluating the model on rated jobs
- document the new metrics
- test model evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c57848c808330a643c64c2ad1ac28