### PR TITLE
Enhance AI cleanup and stats layout

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -83,8 +83,8 @@ def format_salary(min_amount: float, max_amount: float, currency: str) -> str:
     """Return a salary range rounded to the nearest thousand with 'k' suffix."""
     def to_k(val: float) -> str:
         return f"{round(val / 1000):.0f}k"
-
-    return f"{to_k(min_amount)} - {to_k(max_amount)} {currency}"
+    cur = "$" if not currency or currency.upper() == "USD" else currency
+    return f"{cur}{to_k(min_amount)} - {cur}{to_k(max_amount)}"
 
 templates.env.globals["format_salary"] = format_salary
 
@@ -260,6 +260,7 @@ def stats(request: Request):
             "stats": agg,
             "predictions": predictions,
             "model_stats": model_stats,
+            "container_class": "container-fluid",
         },
     )
 
@@ -302,6 +303,15 @@ def reprocess_jobs_task() -> None:
     log_progress("Done")
 
 
+def regen_job_task(job_id: int) -> None:
+    """Regenerate AI data for a single role."""
+    if not OLLAMA_ENABLED:
+        return
+    log_progress(f"Regenerating job {job_id}")
+    regenerate_job_ai(job_id)
+    log_progress("Done")
+
+
 @app.post("/reprocess", response_class=HTMLResponse)
 def reprocess(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
@@ -313,6 +323,13 @@ def reprocess(request: Request, background_tasks: BackgroundTasks):
 def delete_ai(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
     background_tasks.add_task(clear_ai_data_task)
+    return templates.TemplateResponse("progress.html", {"request": request})
+
+
+@app.post("/regen_job/{job_id}", response_class=HTMLResponse)
+def regen_job(request: Request, job_id: int, background_tasks: BackgroundTasks):
+    progress_logs.clear()
+    background_tasks.add_task(regen_job_task, job_id)
     return templates.TemplateResponse("progress.html", {"request": request})
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,7 +18,7 @@
       </div>
     </div>
   </nav>
-  <main class="container my-4 flex-fill">
+  <main class="{{ container_class|default('container') }} my-4 flex-fill">
   {% block content %}{% endblock %}
   </main>
   <footer class="footer text-center mt-auto">Build: {{ build_number }}</footer>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-4">Job Feedback</h1>
 <table class="table table-striped">
-  <tr><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th></tr>
+  <tr><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th><th></th></tr>
   {% for j in jobs %}
   <tr>
     <td>{{ loop.index }}</td>
@@ -25,6 +25,11 @@
       {% else %}
       -
       {% endif %}
+    </td>
+    <td>
+      <form method="post" action="/regen_job/{{ j.id }}" onsubmit="return confirm('Regenerate AI data for this job?');">
+        <button class="btn btn-sm btn-secondary" type="submit">Regen</button>
+      </form>
     </td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add table for cleaned job fields
- integrate Ollama cleanup steps in AI processing
- compute missing salaries from descriptions
- show stats page full width and add regenerate button for each job
- expose endpoint to regenerate AI data for a single job
- format salaries without currency suffix

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d24be473c833083777db3d9602823