### PR TITLE
Enhance AI cleanup and stats layout

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,7 +18,7 @@
       </div>
     </div>
   </nav>
-  <main class="container my-4 flex-fill">
+  <main class="{{ container_class|default('container') }} my-4 flex-fill">
   {% block content %}{% endblock %}
   </main>
   <footer class="footer text-center mt-auto">Build: {{ build_number }}</footer>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-4">Job Feedback</h1>
 <table class="table table-striped">
-  <tr><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th></tr>
+  <tr><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th><th></th></tr>
   {% for j in jobs %}
   <tr>
     <td>{{ loop.index }}</td>
@@ -25,6 +25,11 @@
       {% else %}
       -
       {% endif %}
+    </td>
+    <td>
+      <form method="post" action="/regen_job/{{ j.id }}" onsubmit="return confirm('Regenerate AI data for this job?');">
+        <button class="btn btn-sm btn-secondary" type="submit">Regen</button>
+      </form>
     </td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add table for cleaned job fields
- integrate Ollama cleanup steps in AI processing
- compute missing salaries from descriptions
- show stats page full width and add regenerate button for each job
- expose endpoint to regenerate AI data for a single job
- format salaries without currency suffix
- fix missing import for regen

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d24be473c833083777db3d9602823