### PR TITLE
Improve duplicate review UI

### DIFF
--- a/app/templates/dedup.html
+++ b/app/templates/dedup.html
@@ -2,33 +2,36 @@
 {% block title %}Review Duplicates{% endblock %}
 {% block content %}
 <h1 class="mb-4">Possible Duplicates</h1>
-{% if not pairs %}
+{% if not pair %}
 <p>No potential duplicates found.</p>
 {% else %}
-<ul class="list-group">
-  {% for a,b,sim in pairs %}
-  <li class="list-group-item">
-    <div class="row">
-      <div class="col">
-        <h5>{{ a.title }} - {{ a.company }}</h5>
-        <p>{{ a.location }}</p>
-        <form method="post" action="/delete_job/{{ a.id }}" style="display:inline;">
-          <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this job?');">Delete</button>
-        </form>
-      </div>
-      <div class="col">
-        <h5>{{ b.title }} - {{ b.company }}</h5>
-        <p>{{ b.location }}</p>
-        <form method="post" action="/delete_job/{{ b.id }}" style="display:inline;">
-          <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this job?');">Delete</button>
-        </form>
-      </div>
-      <div class="col-2 d-flex align-items-center">
-        <span class="badge bg-info">{{ (sim*100)|round(0) }}% similar</span>
-      </div>
+<p class="mb-3"><strong>{{ remaining }}</strong> potential duplicate pair{{ remaining!=1 and 's' or '' }} remaining.</p>
+<div class="job-grid">
+  <div class="card job-card">
+    <div class="card-body">
+      <h5 class="card-title">{{ pair[0].title_html | safe }} - {{ pair[0].company_html | safe }}</h5>
+      <p class="card-subtitle mb-2 text-muted">{{ pair[0].location_html | safe }}</p>
+      {% if pair[0].summary %}
+      <div class="ai-summary mb-2">{{ pair[0].summary | safe }}</div>
+      {% endif %}
+      <div class="original-desc job-desc">{{ pair[0].description_html | safe }}</div>
     </div>
-  </li>
-  {% endfor %}
-</ul>
+  </div>
+  <div class="card job-card">
+    <div class="card-body">
+      <h5 class="card-title">{{ pair[1].title_html | safe }} - {{ pair[1].company_html | safe }}</h5>
+      <p class="card-subtitle mb-2 text-muted">{{ pair[1].location_html | safe }}</p>
+      {% if pair[1].summary %}
+      <div class="ai-summary mb-2">{{ pair[1].summary | safe }}</div>
+      {% endif %}
+      <div class="original-desc job-desc">{{ pair[1].description_html | safe }}</div>
+    </div>
+  </div>
+</div>
+<form method="post" action="/dedup_action" class="mt-3 d-flex justify-content-center gap-3">
+  <input type="hidden" name="pair_ids" value="{{ pair[0].id }},{{ pair[1].id }}" />
+  <button class="btn btn-success" name="dup" value="1" type="submit">Duplicates</button>
+  <button class="btn btn-secondary" name="dup" value="0" type="submit">Not Duplicates</button>
+</form>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- highlight differences between potential duplicates
- show duplicate pairs one at a time with remaining count
- allow marking as duplicates or not and remove a random duplicate automatically

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d349c9f388330886695b7a3d0f890