### PR TITLE
Fix model training when only one feedback class

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -29,6 +29,10 @@ def train_model() -> None:
         return
     X = np.array([json.loads(r[1]) for r in rows])
     y = np.array([r[0] for r in rows])
+    # Skip training until we have at least two classes to avoid sklearn errors
+    if len(set(y)) < 2:
+        _model = None
+        return
     _model = LogisticRegression(max_iter=1000)
     _model.fit(X, y)
 


### PR DESCRIPTION
## Summary
- avoid sklearn error if training data contains only one class label
- ensure model uses current DB path in single class test and verify no crash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d352c8a6c8330b7ea95d12f33f719