### PR TITLE
Fix non-duplicate handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from .db import (
     record_feedback,
     cleanup_jobs,
     delete_job,
+    mark_not_duplicates,
     find_duplicate_jobs,
 )
 from .ai import (
@@ -477,6 +478,8 @@ def dedup_action(pair_ids: str = Form(...), dup: int = Form(...)):
     id1, id2 = [int(x) for x in pair_ids.split(",")]
     if dup:
         delete_job(random.choice([id1, id2]))
+    else:
+        mark_not_duplicates(id1, id2)
     return RedirectResponse("/dedup", status_code=303)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -463,6 +463,22 @@ def test_find_duplicate_jobs(main):
     assert a["title"] == b["title"]
 
 
+def test_mark_not_duplicates(main):
+    main.init_db()
+    df = pd.DataFrame([
+        {"site": "a", "title": "Engineer", "company": "X", "location": "L", "date_posted": "d", "description": "desc", "interval": "year", "min_amount": 1, "max_amount": 2, "currency": "USD", "job_url": "http://a.com/1"},
+        {"site": "b", "title": "Engineer", "company": "X", "location": "L", "date_posted": "d", "description": "desc", "interval": "year", "min_amount": 1, "max_amount": 2, "currency": "USD", "job_url": "http://a.com/2"},
+    ])
+    main.save_jobs(df)
+    pairs = main.find_duplicate_jobs(0.5)
+    assert pairs
+    id1 = pairs[0][0]["id"]
+    id2 = pairs[0][1]["id"]
+    main.mark_not_duplicates(id1, id2)
+    pairs = main.find_duplicate_jobs(0.5)
+    assert pairs == []
+
+
 def test_train_model_single_class(main):
     """Model training should handle only one feedback class gracefully."""
     main.init_db()


### PR DESCRIPTION
## Summary
- add a table to record non-duplicate job pairs
- provide `mark_not_duplicates` helper
- call it from the dedupe endpoint
- avoid showing ignored pairs in `find_duplicate_jobs`
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4b4185c08330a41727fc1c1cb139