### PR TITLE
Improve duplicate review display

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -369,7 +369,7 @@ def find_duplicate_jobs(threshold: float = 0.85) -> List[Tuple[Dict, Dict, float
     """Return pairs of potentially duplicate jobs based on text similarity."""
     conn = sqlite3.connect(app_main.DATABASE)
     df = pd.read_sql_query(
-        "SELECT id, title, company, location, description FROM jobs", conn
+        "SELECT id, site, title, company, location, description FROM jobs", conn
     )
     cur = conn.cursor()
     cur.execute("SELECT job_id1, job_id2 FROM not_duplicates")

--- a/app/templates/dedup.html
+++ b/app/templates/dedup.html
@@ -9,6 +9,7 @@
 <div class="job-grid">
   <div class="card job-card">
     <div class="card-body">
+      <p class="text-end text-muted small">Source: {{ pair[0].site }}</p>
       <h5 class="card-title">{{ pair[0].title_html | safe }} - {{ pair[0].company_html | safe }}</h5>
       <p class="card-subtitle mb-2 text-muted">{{ pair[0].location_html | safe }}</p>
       {% if pair[0].summary %}
@@ -19,6 +20,7 @@
   </div>
   <div class="card job-card">
     <div class="card-body">
+      <p class="text-end text-muted small">Source: {{ pair[1].site }}</p>
       <h5 class="card-title">{{ pair[1].title_html | safe }} - {{ pair[1].company_html | safe }}</h5>
       <p class="card-subtitle mb-2 text-muted">{{ pair[1].location_html | safe }}</p>
       {% if pair[1].summary %}


### PR DESCRIPTION
## Summary
- show the job site on the duplicate review page
- render HTML descriptions when highlighting duplicate jobs
- include job site in duplicate finder

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d50d568348330ba6cf78b6cc7ec3a