### PR TITLE
Improve company cleanup logic

### DIFF
--- a/app/ai.py
+++ b/app/ai.py
@@ -37,7 +37,10 @@ Job posting:
 """{description}"""
 '''
 
-CLEAN_COMPANY_PROMPT = "Clean up the company name: '{name}'. Return the corrected capitalization without corporate suffixes." 
+CLEAN_COMPANY_PROMPT = (
+    "Clean up the company name: '{name}'. Remove corporate suffixes like Inc., LLC or Ltd. "
+    "Correct the capitalization and return ONLY the cleaned name without any extra text."
+)
 CLEAN_TITLE_PROMPT = "Simplify the job title by removing words like full-time or hybrid but keep codes: '{title}'. Return the cleaned title." 
 SALARY_PROMPT = (
     "Extract the annual salary range from this text. "
@@ -100,7 +103,14 @@ def clean_company(name: str) -> str:
             timeout=120,
         )
         r.raise_for_status()
-        return r.json().get("response", name).strip()
+        resp = r.json().get("response", name).strip()
+        if (
+            len(resp) > len(name) + 2
+            or ":" in resp
+            or "\n" in resp
+        ):
+            return name
+        return resp
     except Exception as exc:
         logger.info(f"Company cleanup failed: {exc}")
         return name

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+import types
+import importlib
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def make_response(text):
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"response": text}
+
+    return Resp()
+
+
+@pytest.fixture
+def ai_module(monkeypatch):
+    # Provide a minimal stub for app.main to avoid circular imports
+    stub_main = types.ModuleType("app.main")
+    monkeypatch.setitem(sys.modules, "app.main", stub_main)
+    ai = importlib.import_module("app.ai")
+    importlib.reload(ai)
+    yield ai
+    # Remove imported modules so later tests can reload with correct env
+    for mod in ["app.ai", "app.config"]:
+        sys.modules.pop(mod, None)
+
+
+def test_clean_company_rejects_long(ai_module, monkeypatch):
+    ai = ai_module
+    monkeypatch.setattr(ai, "OLLAMA_ENABLED", True)
+    monkeypatch.setattr(
+        ai.requests,
+        "post",
+        lambda *a, **k: make_response(
+            "Hired by Matrix Explanation: 'Inc.' is a corporate suffix"
+        ),
+    )
+    assert ai.clean_company("Hired by Matrix Inc.") == "Hired by Matrix Inc."
+
+
+def test_clean_company_accepts_clean(ai_module, monkeypatch):
+    ai = ai_module
+    monkeypatch.setattr(ai, "OLLAMA_ENABLED", True)
+    monkeypatch.setattr(
+        ai.requests,
+        "post",
+        lambda *a, **k: make_response("JPMorgan Chase"),
+    )
+    assert ai.clean_company("JPMorgan Chase & Co.") == "JPMorgan Chase"


### PR DESCRIPTION
## Summary
- refine LLM prompt for company cleanup
- ignore suspicious AI output when cleaning company names
- add unit tests for company name cleaning

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d539399b483308ec2a71d07570583