### PR TITLE
Add company re-cleaning to regen

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 import types
 import importlib
+import sys
+import sqlite3
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -53,3 +55,49 @@ def test_clean_company_accepts_clean(ai_module, monkeypatch):
         lambda *a, **k: make_response("JPMorgan Chase"),
     )
     assert ai.clean_company("JPMorgan Chase & Co.") == "JPMorgan Chase"
+
+
+def test_regenerate_job_ai_updates_clean_data(tmp_path, monkeypatch):
+    db_path = tmp_path / "t.db"
+    stub_main = types.ModuleType("app.main")
+    stub_main.DATABASE = str(db_path)
+    monkeypatch.setitem(sys.modules, "app.main", stub_main)
+
+    import importlib
+    ai = importlib.import_module("app.ai")
+    importlib.reload(ai)
+    db = importlib.import_module("app.db")
+    importlib.reload(db)
+
+    monkeypatch.setattr(ai, "OLLAMA_ENABLED", True)
+    monkeypatch.setattr(ai, "generate_summary", lambda t: "sum")
+    monkeypatch.setattr(ai, "embed_text", lambda t: [0.0])
+    monkeypatch.setattr(ai, "clean_title", lambda t: t)
+    monkeypatch.setattr(ai, "clean_company", lambda t: "Clean")
+    monkeypatch.setattr(ai, "infer_salary", lambda t: (1.0, 2.0))
+
+    db.init_db()
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO jobs(site,title,company,location,date_posted,description,interval,currency,job_url)
+        VALUES('s','t','C LLC','L','d','desc','year','USD','u')
+        """
+    )
+    job_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+
+    ai.regenerate_job_ai(job_id)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT company, min_amount, max_amount FROM clean_jobs WHERE job_id=?", (job_id,))
+    row = cur.fetchone()
+    conn.close()
+
+    assert row == ("Clean", 1.0, 2.0)
+
+    for mod in ["app.ai", "app.db", "app.main", "app.model", "app.config"]:
+        sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- update `process_all_jobs` and `regenerate_job_ai` to refresh cleaned data when the company or salary are missing
- add regression test for `regenerate_job_ai`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d562c93508330871d199e48c49cc4