### PR TITLE
Implement bulk regeneration and table features

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -390,6 +390,16 @@ def regen_job_task(job_id: int) -> None:
     log_progress("Done")
 
 
+def regen_jobs_task(job_ids: List[int]) -> None:
+    """Regenerate AI data for multiple roles."""
+    if not OLLAMA_ENABLED:
+        return
+    for jid in job_ids:
+        log_progress(f"Regenerating job {jid}")
+        regenerate_job_ai(jid)
+    log_progress("Done")
+
+
 @app.post("/reprocess", response_class=HTMLResponse)
 def reprocess(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
@@ -408,6 +418,13 @@ def delete_ai(request: Request, background_tasks: BackgroundTasks):
 def regen_job(request: Request, job_id: int, background_tasks: BackgroundTasks):
     progress_logs.clear()
     background_tasks.add_task(regen_job_task, job_id)
+    return templates.TemplateResponse("progress.html", {"request": request})
+
+
+@app.post("/regen_jobs", response_class=HTMLResponse)
+def regen_jobs(request: Request, background_tasks: BackgroundTasks, job_ids: List[int] = Form(...)):
+    progress_logs.clear()
+    background_tasks.add_task(regen_jobs_task, job_ids)
     return templates.TemplateResponse("progress.html", {"request": request})
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css" />
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
   <title>{% block title %}Job Ranker{% endblock %}</title>
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -23,6 +24,15 @@
   {% block content %}{% endblock %}
   </main>
   <footer class="footer text-center mt-auto">Build: {{ build_number }}</footer>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.jQuery && $.fn.dataTable) {
+        $('.data-table').DataTable();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -2,17 +2,23 @@
 {% block title %}Job Stats{% endblock %}
 {% block content %}
 <h1 class="mb-4">Job Feedback</h1>
-<table class="table table-striped">
-  <tr><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th><th></th></tr>
+<form method="post" action="/regen_jobs" onsubmit="return confirm('Regenerate AI data for selected jobs?');">
+  <button class="btn btn-sm btn-secondary mb-2" type="submit">Regenerate Selected</button>
+  <table class="table table-striped data-table">
+    <tr><th>Select</th><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th></tr>
   {% for j in jobs %}
   <tr>
+    <td><input type="checkbox" name="job_ids" value="{{ j.id }}" /></td>
     <td>{{ loop.index }}</td>
     <td>
       <a href="{{ j.job_url }}" target="_blank" rel="noopener">{{ j.title }}</a>
       <a class="ms-2" href="/swipe?job_id={{ j.id }}">[view]</a>
     </td>
     <td>{{ j.company }}</td>
-    <td>{{ time_since_posted(j.date_posted) }}</td>
+    <td>
+      {{ time_since_posted(j.date_posted) }}
+      {% if j.date_posted %}<div class="text-muted small">{{ j.date_posted }}</div>{% endif %}
+    </td>
     <td>
       <span class="me-1">{% if j.has_summary %}<span class="text-success">S</span>{% else %}<span class="text-danger">S</span>{% endif %}</span>
       <span>{% if j.has_embedding %}<span class="text-success">E</span>{% else %}<span class="text-danger">E</span>{% endif %}</span>
@@ -26,14 +32,10 @@
       -
       {% endif %}
     </td>
-    <td>
-      <form method="post" action="/regen_job/{{ j.id }}" onsubmit="return confirm('Regenerate AI data for this job?');">
-        <button class="btn btn-sm btn-secondary" type="submit">Regen</button>
-      </form>
-    </td>
   </tr>
   {% endfor %}
 </table>
+</form>
 
 <h2 class="mt-5">Aggregate Stats</h2>
 <p>Total jobs stored: {{ stats.total_jobs }}</p>
@@ -41,7 +43,7 @@
 <p>Jobs with embeddings: {{ stats.jobs_with_embeddings }}</p>
 
 <h3>Roles per Source</h3>
-<table class="table table-sm">
+<table class="table table-sm data-table">
   <tr><th>Site</th><th>Count</th></tr>
   {% for site, count in stats.by_site.items() %}
   <tr><td>{{ site }}</td><td>{{ count }}</td></tr>
@@ -49,7 +51,7 @@
 </table>
 
 <h3>Posts by Date</h3>
-<table class="table table-sm">
+<table class="table table-sm data-table">
   <tr><th>Date</th><th>Count</th></tr>
   {% for date, count in stats.by_date.items() %}
   <tr><td>{{ date }}</td><td>{{ count }}</td></tr>
@@ -75,7 +77,7 @@
 
 <h2 class="mt-5">Predicted Matches</h2>
 {% if predictions %}
-<table class="table table-sm">
+<table class="table table-sm data-table">
   <tr><th>Title</th><th>Company</th><th>Confidence</th></tr>
   {% for p in predictions %}
   <tr>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,7 @@
 import bleach
 
 ALLOWED_TAGS = list(bleach.sanitizer.ALLOWED_TAGS) + [
-    'p', 'pre', 'span', 'hr', 'br', 'div'
+    'p', 'pre', 'span', 'hr', 'br', 'div', 'mark'
 ]
 ALLOWED_ATTRIBUTES = {
     '*': ['class', 'style'],


### PR DESCRIPTION
## Summary
- enable `<mark>` tag for diff highlighting
- integrate DataTables globally for table search, sort and pagination
- show posted date on stats table
- add bulk AI regeneration with checkbox selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d95de39808330bb0c4e9d7628f3b0