### PR TITLE
Add match column to predicted jobs

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -52,7 +52,7 @@ def train_model() -> None:
 
 
 def predict_unrated() -> List[Dict]:
-    """Return predictions for unrated jobs sorted by confidence."""
+    """Return predictions for unrated jobs sorted by match then confidence."""
     if _model is None:
         return []
     conn = sqlite3.connect(DATABASE)
@@ -79,8 +79,17 @@ def predict_unrated() -> List[Dict]:
             prob = float(_model.predict_proba([vec])[0, 1])
         except Exception:
             continue
-        results.append({"id": job_id, "title": title, "company": company, "confidence": prob})
-    results.sort(key=lambda x: x["confidence"], reverse=True)
+        match = prob >= 0.5
+        results.append(
+            {
+                "id": job_id,
+                "title": title,
+                "company": company,
+                "confidence": prob,
+                "match": match,
+            }
+        )
+    results.sort(key=lambda x: (x["match"], x["confidence"]), reverse=True)
     return results
 
 

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -91,13 +91,20 @@
 {% if predictions %}
 <table class="table table-sm data-table">
   <thead>
-    <tr><th>Title</th><th>Company</th><th>Confidence</th></tr>
+    <tr><th>Title</th><th>Company</th><th>Match</th><th>Confidence</th></tr>
   </thead>
   <tbody>
   {% for p in predictions %}
   <tr>
     <td><a href="/swipe?job_id={{ p.id }}">{{ p.title }}</a></td>
     <td>{{ p.company }}</td>
+    <td>
+      {% if p.match %}
+        <span class="text-success">✔</span>
+      {% else %}
+        <span class="text-danger">✖</span>
+      {% endif %}
+    </td>
     <td>{{ '{:.0%}'.format(p.confidence) }}</td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- include match flag in `predict_unrated`
- show check/X for predicted matches in stats page
- sort predictions by match then confidence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5395d5188330ad3dc9ae159defe7