### PR TITLE
Add CSV upload and improved dedup logic

### DIFF
--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -14,6 +14,12 @@
 <form class="mt-3" method="get" action="/export_likes">
   <button class="btn btn-primary" type="submit">Download Liked Jobs</button>
 </form>
+<form class="mt-3" method="post" action="/upload_csv" enctype="multipart/form-data">
+  <div class="mb-2">
+    <input class="form-control" type="file" name="file" accept=".csv" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Upload CSV</button>
+</form>
 {% if deleted is not none %}
 <p class="mt-3">{{ deleted }} jobs deleted.</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- add CSV upload form and endpoint
- store uploaded jobs marked as matches
- keep uploaded jobs when resolving duplicates and preserve ratings when newer postings appear
- enhance `save_jobs` to return inserted ids and merge duplicates
- test custom CSV import and dedup logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e54cee50883308ec318c6e6b040c9