### PR TITLE
Fix predicted confidence display when model unavailable

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -249,6 +249,8 @@ def get_random_job() -> Optional[Dict]:
         chosen = random.choices(jobs, weights=weights, k=1)[0]
     else:
         chosen = random.choice(jobs)
+        chosen["predicted_confidence"] = None
+        chosen["predicted_match"] = None
 
     chosen.pop("embedding", None)
     return chosen
@@ -297,6 +299,9 @@ def get_job(job_id: int) -> Optional[Dict]:
                     job["predicted_match"] = prob >= 0.5
                 except Exception:
                     pass
+        if "predicted_confidence" not in job:
+            job["predicted_confidence"] = None
+            job["predicted_match"] = None
         job.pop("embedding", None)
         return job
     return None

--- a/app/templates/swipe.html
+++ b/app/templates/swipe.html
@@ -19,7 +19,7 @@
     {% else %}
     <p>No description available.</p>
     {% endif %}
-    {% if job.predicted_confidence is not none %}
+    {% if job.predicted_confidence is defined and job.predicted_confidence is not none %}
     <div class="alert alert-info text-center mt-3">
       Model prediction:
       {% if job.predicted_match %}


### PR DESCRIPTION
## Summary
- ensure `get_random_job` and `get_job` set prediction fields even when the model isn't loaded
- guard the swipe template against undefined prediction values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e930927248330a203e2d0155ce626