### PR TITLE
Add Source column to export and format rated date

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -456,7 +456,8 @@ def list_liked_jobs() -> pd.DataFrame:
     """Return a DataFrame of positively rated jobs with rating timestamps."""
     conn = sqlite3.connect(app_main.DATABASE)
     query = """
-        SELECT COALESCE(c.company, j.company) AS company,
+        SELECT j.site,
+               COALESCE(c.company, j.company) AS company,
                COALESCE(c.title, j.title) AS title,
                j.location, j.date_posted,
                f.rated_at,

--- a/app/main.py
+++ b/app/main.py
@@ -444,7 +444,8 @@ def export_likes():
     """Download positively rated jobs as an Excel file."""
     df = list_liked_jobs()
     if not df.empty:
-        df["Date Rated"] = pd.to_datetime(df["rated_at"], unit="s").dt.date
+        rated = pd.to_datetime(df["rated_at"], unit="s", errors="coerce")
+        df["Date Rated"] = rated.dt.strftime("%-m/%-d/%Y")
         df["Pay Range"] = df.apply(
             lambda r: format_salary(r["min_amount"], r["max_amount"], r["currency"])
             if (
@@ -458,6 +459,7 @@ def export_likes():
         )
         df = df.rename(
             columns={
+                "site": "Source",
                 "company": "Company",
                 "title": "Job Title",
                 "location": "Location",
@@ -472,6 +474,7 @@ def export_likes():
         df["Notes"] = ""
         df = df[
             [
+                "Source",
                 "Company",
                 "Job Title",
                 "Location",
@@ -485,6 +488,7 @@ def export_likes():
     else:
         df = pd.DataFrame(
             columns=[
+                "Source",
                 "Company",
                 "Job Title",
                 "Location",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -564,7 +564,8 @@ def test_list_liked_jobs(main):
         }
     ])
     main.save_jobs(df)
-    main.record_feedback(1, True, "")
+    ts = int(pd.Timestamp("2025-07-21").timestamp())
+    main.record_feedback(1, True, "", rated_at=ts)
     liked = main.list_liked_jobs()
     assert len(liked) == 1
     assert liked["company"].iloc[0] == "C"
@@ -711,7 +712,8 @@ def test_export_likes_formats_fields(main, monkeypatch):
         }
     ])
     main.save_jobs(df)
-    main.record_feedback(1, True, "")
+    ts = int(pd.Timestamp("2025-07-21").timestamp())
+    main.record_feedback(1, True, "", rated_at=ts)
 
     captured = {}
 
@@ -722,9 +724,11 @@ def test_export_likes_formats_fields(main, monkeypatch):
     main.export_likes()
 
     out = captured["df"]
+    assert list(out.columns)[0] == "Source"
     assert out.loc[0, "Location"] == "Cincinnati, OH"
     assert out.loc[0, "Pay Range"] == ""
     assert out.loc[0, "Date Posted"] == "7/20/2025"
+    assert out.loc[0, "Date Rated"] == "7/21/2025"
 
 
 def test_import_custom_csv_marks_match(main):


### PR DESCRIPTION
## Summary
- include the site name when exporting liked jobs
- format the rated date as `M/D/YYYY`
- update tests for new export structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e989a77a083308a27b26d269b5b7f