### PR TITLE
Fix exported job spreadsheet

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -442,7 +442,10 @@ def export_likes():
     df = list_liked_jobs()
     if not df.empty:
         rated = pd.to_datetime(df["rated_at"], unit="s", errors="coerce")
-        df["Date Rated"] = rated.dt.strftime("%-m/%-d/%Y")
+        df["Farmed Date"] = rated.dt.strftime("%-m/%-d/%Y")
+
+        df["min_amount"] = pd.to_numeric(df["min_amount"], errors="coerce")
+        df["max_amount"] = pd.to_numeric(df["max_amount"], errors="coerce")
         df["Pay Range"] = df.apply(
             lambda r: format_salary(r["min_amount"], r["max_amount"], r["currency"])
             if (
@@ -476,7 +479,7 @@ def export_likes():
                 "Job Title",
                 "Location",
                 "Date Posted",
-                "Date Rated",
+                "Farmed Date",
                 "Pay Range",
                 "Notes",
                 "Link",
@@ -490,7 +493,7 @@ def export_likes():
                 "Job Title",
                 "Location",
                 "Date Posted",
-                "Date Rated",
+                "Farmed Date",
                 "Pay Range",
                 "Notes",
                 "Link",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -729,7 +729,7 @@ def test_export_likes_formats_fields(main, monkeypatch):
     assert out.loc[0, "Location"] == "Cincinnati, OH"
     assert out.loc[0, "Pay Range"] == ""
     assert out.loc[0, "Date Posted"] == "7/20/2025"
-    assert out.loc[0, "Date Rated"] == "7/21/2025"
+    assert out.loc[0, "Farmed Date"] == "7/21/2025"
 
 
 def test_import_custom_csv_marks_match(main):


### PR DESCRIPTION
## Summary
- tweak export to rename "Date Rated" to "Farmed Date"
- clean salary columns so zero values don't appear
- update tests for new header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb59a9b50833094d2bb131ef995f5