### PR TITLE
Add DB migration for tags column

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -47,6 +47,13 @@ def init_db() -> None:
         )
         """
     )
+    # Add new columns to existing feedback tables without losing data
+    cur.execute("PRAGMA table_info(feedback)")
+    existing_cols = {r[1] for r in cur.fetchall()}
+    if "tags" not in existing_cols:
+        cur.execute("ALTER TABLE feedback ADD COLUMN tags TEXT")
+    if "rated_at" not in existing_cols:
+        cur.execute("ALTER TABLE feedback ADD COLUMN rated_at INTEGER")
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS embeddings(


### PR DESCRIPTION
## Summary
- support upgrading existing `feedback` table by adding missing columns
- test that `init_db` upgrades an old database schema without losing data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb60f9a048330b1e7ade3ee226fd9