### PR TITLE
Fix Bleach warning by removing style attribute

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -4,7 +4,7 @@ ALLOWED_TAGS = list(bleach.sanitizer.ALLOWED_TAGS) + [
     'p', 'pre', 'span', 'hr', 'br', 'div', 'mark'
 ]
 ALLOWED_ATTRIBUTES = {
-    '*': ['class', 'style'],
+    '*': ['class'],
     'a': ['href', 'rel', 'target'],
 }
 


### PR DESCRIPTION
## Summary
- clean HTML without allowing the `style` attribute

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec4464cac83309f122ba4f8167ad2