### PR TITLE
Improve job matching model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ docker compose up
    using the green ✓ button to mark a good match or the red ✖ button to
    reject it. After choosing either option you will be shown a list of
    tags extracted from the posting and can select which ones influenced
-   your decision. Feedback is stored in a SQLite database inside the container to help train a future matching model.
+   your decision. These tags are stored along with your feedback and
+   incorporated when training the matching model.
    If any job boards fail to fetch (for example due to network restrictions) the
    progress screen now shows detailed logs so you can see which sources were skipped.
    A statistics page summarizes stored jobs and reports model accuracy, precision and recall so you can track its performance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,8 +12,9 @@ This project is a small job search and ranking tool built with **FastAPI**. Jobs
 - **Job Scraping** – `jobspy.scrape_jobs`
   - Called from the background task to collect jobs from sites like LinkedIn, Indeed, ZipRecruiter, Glassdoor and Google.
 - **Database** – SQLite stored at the path in the `DATABASE` env var.
-  - Tables: `jobs`, `feedback`, `embeddings` and `summaries`.
+  - Tables: `jobs`, `feedback`, `embeddings`, `summaries` and `job_tags`.
   - `jobs` holds raw postings. `feedback` records user ratings and reasons.
+  - `job_tags` stores skills extracted from each description.
   - `embeddings` and `summaries` are optionally populated using Ollama.
 - **Ollama Integration**
   - When `OLLAMA_BASE_URL` is set, descriptions are summarized and embedded via Ollama’s API. The model name defaults to `llama3` and can be changed with `OLLAMA_MODEL`.


### PR DESCRIPTION
## Summary
- include job tags in the logistic regression model
- expose tag binarizer in model module
- adjust predictions to use tag features
- document new behaviour in README and architecture docs
- test that tags influence predictions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec528a8a483309f3d5d9cc90f0a5d