### PR TITLE
Fix dedup crash when job dates missing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -538,10 +538,14 @@ def dedup_action(pair_ids: str = Form(...), dup: int = Form(...)):
         j2 = get_job(id2)
 
         def parse_date(d: str) -> pd.Timestamp:
+            """Return parsed UTC timestamp or Timestamp.min if invalid."""
+            if not d:
+                return pd.Timestamp.min
             try:
-                return pd.to_datetime(d, utc=True)
+                dt = pd.to_datetime(d, utc=True, errors="coerce")
             except Exception:
                 return pd.Timestamp.min
+            return dt if not pd.isna(dt) else pd.Timestamp.min
 
         if j1 and j1.get("site") == "upload":
             keep, remove = id1, id2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -847,6 +847,24 @@ def test_dedup_action_keeps_uploaded(main):
     assert site == "upload"
 
 
+def test_dedup_action_handles_missing_dates(main):
+    main.init_db()
+    id1 = main.save_jobs(pd.DataFrame([
+        {"site": "t", "title": "Dev1", "company": "A", "job_url": "d1", "description": "x1", "date_posted": None}
+    ]))[0]
+    id2 = main.save_jobs(pd.DataFrame([
+        {"site": "t", "title": "Dev2", "company": "A", "job_url": "d2", "description": "x2", "date_posted": None}
+    ]))[0]
+    # Should not raise even when dates are missing
+    main.dedup_action(f"{id1},{id2}", 1)
+    conn = sqlite3.connect(main.DATABASE)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM jobs")
+    count = cur.fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
 def test_model_uses_tags(main):
     main.init_db()
     import importlib


### PR DESCRIPTION
## Summary
- handle `None` dates when deduplicating jobs
- add regression test for dedup action with missing dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8e0d5a488330a8103fe06a28b4b4