### PR TITLE
Evaluate model on 10% holdout set

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ docker compose up
    your decision. These tags are stored along with your feedback and
    incorporated when training the matching model.
    If any job boards fail to fetch (for example due to network restrictions) the
-   progress screen now shows detailed logs so you can see which sources were skipped.
-   A statistics page summarizes stored jobs and reports model accuracy, precision and recall so you can track its performance.
+  progress screen now shows detailed logs so you can see which sources were skipped.
+  A statistics page summarizes stored jobs and reports model accuracy, precision and recall using a 10% holdout set so you can track its performance. It also lists how many roles have been rated positively, negatively or not at all.
 
 The application uses [JobSpy](https://pypi.org/project/python-jobspy/) to scrape
 job boards and FastAPI for the web interface. If LinkedIn descriptions are

--- a/app/db.py
+++ b/app/db.py
@@ -399,6 +399,14 @@ def aggregate_job_stats() -> Dict:
     cur.execute("SELECT COUNT(*) FROM embeddings")
     embeddings_count = cur.fetchone()[0]
 
+    cur.execute("SELECT COUNT(DISTINCT job_id) FROM feedback")
+    rated_total = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(DISTINCT job_id) FROM feedback WHERE liked=1")
+    positive_total = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(DISTINCT job_id) FROM feedback WHERE liked=0")
+    negative_total = cur.fetchone()[0]
+    unrated_total = total_jobs - rated_total
+
     conn.close()
     return {
         "total_jobs": total_jobs,
@@ -408,6 +416,10 @@ def aggregate_job_stats() -> Dict:
         "avg_max_pay": avg_max or 0,
         "jobs_with_summaries": summaries_count,
         "jobs_with_embeddings": embeddings_count,
+        "rated_roles": rated_total,
+        "positive_roles": positive_total,
+        "negative_roles": negative_total,
+        "unrated_roles": unrated_total,
     }
 
 

--- a/app/model.py
+++ b/app/model.py
@@ -1,6 +1,6 @@
 import json
 from .database import connect_db
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 
 import numpy as np
 from sklearn.linear_model import LogisticRegression
@@ -10,11 +10,13 @@ from .config import DATABASE
 
 _model: LogisticRegression | None = None
 _tag_binarizer: MultiLabelBinarizer | None = None
+_eval_set: Tuple[np.ndarray, np.ndarray] | None = None
+_known_tags: Set[str] = set()
 
 
 def train_model() -> None:
     """Train a logistic regression model from feedback, embeddings and tags."""
-    global _model, _tag_binarizer
+    global _model, _tag_binarizer, _known_tags
     conn = connect_db()
     cur = conn.cursor()
     cur.execute(
@@ -31,6 +33,8 @@ def train_model() -> None:
     if not rows:
         _model = None
         _tag_binarizer = None
+        _eval_set = None
+        _known_tags = set()
         return
     X_emb: List[List[float]] = []
     tag_sets: List[List[str]] = []
@@ -59,17 +63,36 @@ def train_model() -> None:
     if not X_emb:
         _model = None
         _tag_binarizer = None
+        _eval_set = None
+        _known_tags = set()
         return
     _tag_binarizer = MultiLabelBinarizer()
     tag_matrix = _tag_binarizer.fit_transform(tag_sets)
+    _known_tags = set(_tag_binarizer.classes_)
     X = np.hstack([np.array(X_emb), tag_matrix])
     y = np.array(y_list)
     if len(set(y)) < 2:
         _model = None
         _tag_binarizer = None
+        _eval_set = None
+        _known_tags = set()
         return
+    rng = np.random.default_rng(0)
+    idx = np.arange(len(y))
+    rng.shuffle(idx)
+    test_size = max(1, int(len(y) * 0.1)) if len(y) > 1 else 0
+    test_idx = idx[:test_size]
+    train_idx = idx[test_size:]
+    if len(train_idx) < 2 or len(set(y[train_idx])) < 2:
+        train_idx = idx
+        test_idx = []
+    X_train = X[train_idx]
+    y_train = y[train_idx]
+    X_test = X[test_idx]
+    y_test = y[test_idx]
     _model = LogisticRegression(max_iter=1000)
-    _model.fit(X, y)
+    _model.fit(X_train, y_train)
+    _eval_set = (X_test, y_test)
 
 
 def predict_unrated() -> List[Dict]:
@@ -99,7 +122,8 @@ def predict_unrated() -> List[Dict]:
             continue
         tag_list = [t.strip() for t in str(tags).split(',') if t.strip()] if tags else []
         if _tag_binarizer is not None:
-            tag_vec = _tag_binarizer.transform([tag_list])[0]
+            filtered = [t for t in tag_list if t in _known_tags]
+            tag_vec = _tag_binarizer.transform([filtered])[0]
             feat = np.hstack([vec, tag_vec])
         else:
             feat = vec
@@ -150,7 +174,8 @@ def predict_job(job_id: int) -> Optional[Tuple[bool, float]]:
     tags = row[1] if row and len(row) > 1 else None
     tag_list = [t.strip() for t in str(tags).split(',') if t.strip()] if tags else []
     if _tag_binarizer is not None:
-        tag_vec = _tag_binarizer.transform([tag_list])[0]
+        filtered = [t for t in tag_list if t in _known_tags]
+        tag_vec = _tag_binarizer.transform([filtered])[0]
         feat = np.hstack([vec, tag_vec])
     else:
         feat = vec
@@ -166,8 +191,8 @@ def predict_job(job_id: int) -> Optional[Tuple[bool, float]]:
 
 
 def evaluate_model() -> Dict[str, float | int]:
-    """Return basic accuracy stats comparing predictions to feedback."""
-    if _model is None:
+    """Return accuracy metrics using the holdout set from training."""
+    if _model is None or _eval_set is None:
         return {
             "total": 0,
             "tp": 0,
@@ -179,20 +204,8 @@ def evaluate_model() -> Dict[str, float | int]:
             "recall": 0.0,
         }
 
-    conn = connect_db()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT f.liked, e.embedding, f.tags, GROUP_CONCAT(t.tag)
-        FROM feedback f
-        JOIN embeddings e ON f.job_id = e.job_id
-        LEFT JOIN job_tags t ON f.job_id = t.job_id
-        GROUP BY f.id
-        """
-    )
-    rows = cur.fetchall()
-    conn.close()
-    if not rows:
+    X_test, y_test = _eval_set
+    if len(y_test) == 0:
         return {
             "total": 0,
             "tp": 0,
@@ -204,64 +217,12 @@ def evaluate_model() -> Dict[str, float | int]:
             "recall": 0.0,
         }
 
-    expected_dim = getattr(_model, "n_features_in_", None)
-    X_emb: List[List[float]] = []
-    tag_sets: List[List[str]] = []
-    y_list: List[int] = []
-    for liked, emb, fb_tags, job_tags in rows:
-        vec = json.loads(emb)
-        if not vec:
-            continue
-        if X_emb and len(vec) != len(X_emb[0]):
-            continue
-        tags = []
-        if fb_tags:
-            tags.extend(t.strip() for t in str(fb_tags).split(',') if t.strip())
-        if job_tags:
-            tags.extend(t.strip() for t in str(job_tags).split(',') if t.strip())
-        seen = set()
-        uniq = []
-        for t in tags:
-            tl = t.lower()
-            if tl not in seen:
-                seen.add(tl)
-                uniq.append(t)
-        X_emb.append(vec)
-        tag_sets.append(uniq)
-        y_list.append(liked)
-    if not X_emb:
-        return {
-            "total": 0,
-            "tp": 0,
-            "tn": 0,
-            "fp": 0,
-            "fn": 0,
-            "accuracy": 0.0,
-            "precision": 0.0,
-            "recall": 0.0,
-        }
-
-    if _tag_binarizer is None:
-        return {
-            "total": 0,
-            "tp": 0,
-            "tn": 0,
-            "fp": 0,
-            "fn": 0,
-            "accuracy": 0.0,
-            "precision": 0.0,
-            "recall": 0.0,
-        }
-    tag_matrix = _tag_binarizer.transform(tag_sets) if tag_sets else np.zeros((len(tag_sets), 0))
-    X = np.hstack([np.array(X_emb), tag_matrix])
-    y = np.array(y_list)
-    preds = _model.predict(X)
-
-    tp = int(np.sum((preds == 1) & (y == 1)))
-    tn = int(np.sum((preds == 0) & (y == 0)))
-    fp = int(np.sum((preds == 1) & (y == 0)))
-    fn = int(np.sum((preds == 0) & (y == 1)))
-    total = len(y)
+    preds = _model.predict(X_test)
+    tp = int(np.sum((preds == 1) & (y_test == 1)))
+    tn = int(np.sum((preds == 0) & (y_test == 0)))
+    fp = int(np.sum((preds == 1) & (y_test == 0)))
+    fn = int(np.sum((preds == 0) & (y_test == 1)))
+    total = len(y_test)
 
     accuracy = (tp + tn) / total if total else 0.0
     precision = tp / (tp + fp) if (tp + fp) else 0.0

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -45,6 +45,8 @@
 <p>Total jobs stored: {{ stats.total_jobs }}</p>
 <p>Jobs with summaries: {{ stats.jobs_with_summaries }}</p>
 <p>Jobs with embeddings: {{ stats.jobs_with_embeddings }}</p>
+<p>Rated roles: {{ stats.rated_roles }} ({{ stats.positive_roles }} liked, {{ stats.negative_roles }} disliked)</p>
+<p>Unrated roles: {{ stats.unrated_roles }}</p>
 
 <h3>Roles per Source</h3>
 <table class="table table-sm data-table">
@@ -75,6 +77,7 @@
 <h2 class="mt-5">Model Performance</h2>
 {% if model_stats.total > 0 %}
 <ul>
+  <li>Evaluated on {{ model_stats.total }} samples</li>
   <li>Accuracy: {{ '{:.0%}'.format(model_stats.accuracy) }}</li>
   <li>Precision: {{ '{:.0%}'.format(model_stats.precision) }}</li>
   <li>Recall: {{ '{:.0%}'.format(model_stats.recall) }}</li>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ This project is a small job search and ranking tool built with **FastAPI**. Jobs
     captures more context when ranking roles.
 - **Client UI**
   - HTML templates render pages for searching, swiping, viewing stats and managing stored jobs. Styling lives in `app/static/style.css`.
-  - The stats page also shows model performance including accuracy, precision, recall and counts of false/true positives and negatives.
+  - The stats page also shows model performance including accuracy, precision, recall and counts of false/true positives and negatives. Metrics are calculated on a 10% holdout sample from the feedback data. Aggregate stats also summarize how many roles were liked, disliked or left unrated.
 - **Tests** – under `tests/` using `pytest` to cover database operations and job fetching logic.
 - **Docker** – `Dockerfile` and `build.sh` build a container image. GitHub Actions automatically build and push on merges to `main`.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -427,12 +427,22 @@ def test_aggregate_job_stats(main):
         },
     ])
     main.save_jobs(df)
+    conn = sqlite3.connect(main.DATABASE)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO feedback(job_id, liked, tags, rated_at) VALUES(1,1,'',0)")
+    cur.execute("INSERT INTO feedback(job_id, liked, tags, rated_at) VALUES(2,0,'',0)")
+    conn.commit()
+    conn.close()
     stats = main.aggregate_job_stats()
     assert stats["total_jobs"] == 3
     assert stats["by_site"] == {"a": 2, "b": 1}
     assert stats["by_date"] == {"2024-01-01": 2, "2024-01-02": 1}
     assert stats["avg_min_pay"] == pytest.approx(150)
     assert stats["avg_max_pay"] == pytest.approx(250)
+    assert stats["rated_roles"] == 2
+    assert stats["positive_roles"] == 1
+    assert stats["negative_roles"] == 1
+    assert stats["unrated_roles"] == 1
 
 
 def test_render_markdown(main):
@@ -575,9 +585,9 @@ def test_evaluate_model(main):
     conn.close()
     main.train_model()
     stats = main.evaluate_model()
-    assert stats["total"] == 2
-    assert stats["tp"] + stats["tn"] + stats["fp"] + stats["fn"] == 2
-    assert 0.0 <= stats["accuracy"] <= 1.0
+    assert stats["total"] == 0
+    assert stats["tp"] + stats["tn"] + stats["fp"] + stats["fn"] == 0
+    assert stats["accuracy"] == 0.0
 
 
 def test_list_liked_jobs(main):


### PR DESCRIPTION
## Summary
- hold out 10% of feedback when training
- show evaluation set size in stats page
- document holdout evaluation in README and docs
- update tests for new evaluation method
- filter unknown tags to silence MultiLabelBinarizer warnings
- count rated/unrated roles in aggregate stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fda6228dc8330a6208be30df3bb41