### PR TITLE
Remove stats page data-needed button

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,6 @@ from .config import (
     DATABASE,
     OLLAMA_ENABLED,
     BUILD_NUMBER,
-    MIN_FEEDBACK_FOR_TRAINING,
 )
 from .db import (
     init_db,
@@ -347,7 +346,6 @@ def stats(request: Request):
             "stats": agg,
             "predictions": predictions,
             "model_stats": model_stats,
-            "min_feedback": MIN_FEEDBACK_FOR_TRAINING,
             "container_class": "container-fluid",
         },
     )

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -79,10 +79,6 @@
   <form class="d-inline" method="post" action="/train">
     <button class="btn btn-primary btn-sm" type="submit">Retrain Model</button>
   </form>
-  <button class="btn btn-secondary btn-sm ms-2" type="button"
-          onclick="alert('Rated {{ stats.rated_roles }} of {{ min_feedback }} roles');">
-    Show Data Needed
-  </button>
 </div>
 {% if model_stats.total > 0 %}
 <ul>


### PR DESCRIPTION
## Summary
- remove "Show Data Needed" button from the stats page
- drop unused `min_feedback` context variable and related import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fedb234a083309456eb063eefdd1f