### PR TITLE
Refine summary prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ The application uses [JobSpy](https://pypi.org/project/python-jobspy/) to scrape
 job boards and FastAPI for the web interface. If LinkedIn descriptions are
 missing, the scraper now passes `linkedin_fetch_description=True` which visits
 each LinkedIn job page to pull the full text. When Ollama is enabled the
-AI-generated summary now separates **Required Skills** from **Bonus Skills** so
-it's clear which technologies are mandatory. Embeddings include the title and
-company name along with the full description for better ranking accuracy.
+AI-generated summary strips company mission statements or disclaimers and
+separates **Required Skills** from **Bonus Skills** so it's clear which
+technologies are mandatory. Embeddings include the title and company name along
+with the full description for better ranking accuracy.
 
 ## Documentation
 

--- a/app/ai.py
+++ b/app/ai.py
@@ -15,9 +15,12 @@ from . import main as app_main
 logger = logging.getLogger("job_fetch")
 
 REWRITE_PROMPT_TEMPLATE = '''
-Rewrite the following job description into concise Markdown without preamble.
-Start with two bullet lists: first list the required technologies and then list any bonus or nice-to-have skills. Group alternatives with '/'.
-Skip duplicate items and omit sections that cannot be filled.
+Rewrite the following job description with an eye toward removing fluff. Strip
+company mission statements, marketing language, generic disclaimers and physical
+demands. Boil lengthy sentences down to short phrases so only the true
+requirements and responsibilities remain.
+
+Return concise Markdown organized into bullet lists. Group alternatives with '/' and skip duplicates or empty sections:
 
 ---
 **Required Skills**
@@ -29,6 +32,10 @@ Skip duplicate items and omit sections that cannot be filled.
 - item two
 
 **Soft Skills**
+- item one
+- item two
+
+**Responsibilities**
 - item one
 - item two
 ---

--- a/app/main.py
+++ b/app/main.py
@@ -68,9 +68,12 @@ logging.basicConfig(level=logging.INFO)
 progress_logs = deque(maxlen=100)
 
 REWRITE_PROMPT_TEMPLATE = '''
-Rewrite the following job description into concise Markdown without preamble.
-Start with two bullet lists: first list the required technologies and then list any bonus or nice-to-have skills. Group alternatives with '/'.
-Skip duplicate items and omit sections that cannot be filled.
+Rewrite the following job description with an eye toward removing fluff. Strip
+company mission statements, marketing language, generic disclaimers and physical
+demands. Boil lengthy sentences down to short phrases so only the true
+requirements and responsibilities remain.
+
+Return concise Markdown organized into bullet lists. Group alternatives with '/' and skip duplicates or empty sections:
 
 ---
 **Required Skills**
@@ -82,6 +85,10 @@ Skip duplicate items and omit sections that cannot be filled.
 - item two
 
 **Soft Skills**
+- item one
+- item two
+
+**Responsibilities**
 - item one
 - item two
 ---


### PR DESCRIPTION
## Summary
- fine-tune the prompt used to rephrase job postings
  - instruct the model to strip fluff like mission statements and disclaimers
  - shorten long sentences and capture responsibilities briefly
- update README to mention the trimmed summaries

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800fd13c208330b9723beb4bd910bb