### PR TITLE
Add multi-model training with best model selection

### DIFF
--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -80,17 +80,24 @@
     <button class="btn btn-primary btn-sm" type="submit">Retrain Model</button>
   </form>
 </div>
-{% if model_stats.total > 0 %}
-<ul>
-  <li>Evaluated on {{ model_stats.total }} samples</li>
-  <li>Accuracy: {{ '{:.0%}'.format(model_stats.accuracy) }}</li>
-  <li>Precision: {{ '{:.0%}'.format(model_stats.precision) }}</li>
-  <li>Recall: {{ '{:.0%}'.format(model_stats.recall) }}</li>
-  <li>True Positives: {{ model_stats.tp }}</li>
-  <li>True Negatives: {{ model_stats.tn }}</li>
-  <li>False Positives: {{ model_stats.fp }}</li>
-  <li>False Negatives: {{ model_stats.fn }}</li>
-</ul>
+{% if model_stats.models %}
+<p>Active model: {{ model_stats.model_name }}</p>
+<table class="table table-sm data-table">
+  <thead>
+    <tr><th>Model</th><th>Acc</th><th>Prec</th><th>Recall</th><th>F1</th></tr>
+  </thead>
+  <tbody>
+  {% for m in model_stats.models %}
+  <tr{% if m.name == model_stats.name %} class="table-primary"{% endif %}>
+    <td>{{ m.description }}</td>
+    <td>{{ '{:.0%}'.format(m.accuracy) }}</td>
+    <td>{{ '{:.0%}'.format(m.precision) }}</td>
+    <td>{{ '{:.0%}'.format(m.recall) }}</td>
+    <td>{{ '{:.0%}'.format(m.f1) }}</td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {% else %}
 <p>Not enough data available to evaluate the model.</p>
 {% endif %}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ This project is a small job search and ranking tool built with **FastAPI**. Jobs
     captures more context when ranking roles.
 - **Client UI**
   - HTML templates render pages for searching, swiping, viewing stats and managing stored jobs. Styling lives in `app/static/style.css`.
-  - The stats page also shows model performance including accuracy, precision, recall and counts of false/true positives and negatives. Metrics are calculated on a 10% holdout sample from the feedback data. Aggregate stats also summarize how many roles were liked, disliked or left unrated.
+  - The stats page shows performance for several algorithms (logistic regression, random forest, SVM and a clustering approach). The app trains all of them and keeps the one with the highest recall. Metrics for each candidate are displayed in a table so you can compare their accuracy, precision, recall and F1 score. Results are calculated on a 10% holdout set when possible.
 - **Tests** – under `tests/` using `pytest` to cover database operations and job fetching logic.
 - **Docker** – `Dockerfile` and `build.sh` build a container image. GitHub Actions automatically build and push on merges to `main`.
 


### PR DESCRIPTION
## Summary
- train logistic regression, random forest, SVM and k‑means
- pick the model with the best recall and store metrics for all candidates
- expose metrics and active model name through `evaluate_model`
- show metrics table in the stats UI
- update architecture docs to describe the new training flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688010e86094833094a9a18db126da7d