### PR TITLE
Add neural network model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ docker compose up
   incorporated when training the matching model. Each algorithm is now
   trained twice: once using only the embeddings and again with the tag
   vectors appended. The statistics page lists accuracy metrics for all
-  variants so you can compare their performance.
+  variants so you can compare their performance. In addition to logistic regression,
+  random forests and SVMs, a small neural network is also trained to see if a
+  deep learning approach yields better results.
    If any job boards fail to fetch (for example due to network restrictions) the
   progress screen now shows detailed logs so you can see which sources were skipped.
   A statistics page summarizes stored jobs and reports model accuracy, precision and recall using a 10% holdout set so you can track its performance. It also lists how many roles have been rated positively, negatively or not at all.

--- a/app/model.py
+++ b/app/model.py
@@ -6,6 +6,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.svm import SVC
 from sklearn.cluster import KMeans
+from sklearn.neural_network import MLPClassifier
 from sklearn.preprocessing import MultiLabelBinarizer
 
 from .database import connect_db
@@ -168,6 +169,7 @@ def train_model() -> None:
         ("logreg", LogisticRegression(max_iter=1000), "Logistic Regression"),
         ("forest", RandomForestClassifier(n_estimators=100), "Random Forest"),
         ("svm", SVC(kernel='linear', probability=True), "Support Vector Machine"),
+        ("mlp", MLPClassifier(hidden_layer_sizes=(64, 32), max_iter=500), "Neural Network"),
         ("kmeans", KMeans(n_clusters=2, n_init='auto', random_state=0), "KMeans Clustering"),
     ]
     candidates: List[_ModelWrapper] = []

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ This project is a small job search and ranking tool built with **FastAPI**. Jobs
     captures more context when ranking roles.
 - **Client UI**
   - HTML templates render pages for searching, swiping, viewing stats and managing stored jobs. Styling lives in `app/static/style.css`.
-  - The stats page shows performance for several algorithms (logistic regression, random forest, SVM and a clustering approach). The app trains all of them and keeps the one with the highest recall. Metrics for each candidate are displayed in a table so you can compare their accuracy, precision, recall and F1 score. Results are calculated on a 10% holdout set when possible.
+  - The stats page shows performance for several algorithms (logistic regression, random forest, a neural network, SVM and a clustering approach). The app trains all of them and keeps the one with the highest recall. Metrics for each candidate are displayed in a table so you can compare their accuracy, precision, recall and F1 score. Results are calculated on a 10% holdout set when possible.
 - **Tests** – under `tests/` using `pytest` to cover database operations and job fetching logic.
 - **Docker** – `Dockerfile` and `build.sh` build a container image. GitHub Actions automatically build and push on merges to `main`.
 


### PR DESCRIPTION
## Summary
- include an MLP neural network in model training
- mention the neural network on the stats page docs
- note the additional model in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f791c3348330942272bedd681525