### PR TITLE
Add tag consolidation process

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,6 +59,7 @@ from .ai import (
     render_markdown,
     process_all_jobs,
     regenerate_job_ai,
+    consolidate_similar_tags,
 )
 from .utils import sanitize_html
 from .model import train_model, predict_unrated, evaluate_model, find_outliers
@@ -464,6 +465,15 @@ def regen_jobs_task(job_ids: List[int]) -> None:
     log_progress("Done")
 
 
+def consolidate_tags_task() -> None:
+    """Run tag consolidation using Ollama."""
+    if not OLLAMA_ENABLED:
+        return
+    log_progress("Consolidating tags")
+    consolidate_similar_tags()
+    log_progress("Done")
+
+
 @app.post("/reprocess", response_class=HTMLResponse)
 def reprocess(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
@@ -491,6 +501,13 @@ def regen_jobs(
 ):
     progress_logs.clear()
     background_tasks.add_task(regen_jobs_task, job_ids)
+    return templates.TemplateResponse("progress.html", {"request": request})
+
+
+@app.post("/consolidate_tags", response_class=HTMLResponse)
+def consolidate_tags_endpoint(request: Request, background_tasks: BackgroundTasks):
+    progress_logs.clear()
+    background_tasks.add_task(consolidate_tags_task)
     return templates.TemplateResponse("progress.html", {"request": request})
 
 

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -11,6 +11,9 @@
 <form class="mt-3" method="post" action="/delete_ai" onsubmit="return confirm('Delete all summaries and embeddings?');">
   <button class="btn btn-danger" type="submit">Delete AI Data</button>
 </form>
+<form class="mt-3" method="post" action="/consolidate_tags" onsubmit="return confirm('Merge similar tags?');">
+  <button class="btn btn-secondary" type="submit">Consolidate Tags</button>
+</form>
 <form class="mt-3" method="get" action="/export_likes">
   <button class="btn btn-primary" type="submit">Download Liked Jobs</button>
 </form>


### PR DESCRIPTION
## Summary
- add utility to consolidate similar tags using Ollama
- expose new endpoint `/consolidate_tags` and button on Manage page
- ensure feedback tags are saved when rating jobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688142429f508330874187f008a83d7f