### PR TITLE
Add tag deletion option and ensure tag regeneration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -481,6 +481,18 @@ def consolidate_tags_task() -> None:
     log_progress("Done")
 
 
+def clear_tags_task() -> None:
+    """Remove all stored tags."""
+    log_progress("Deleting tags")
+    conn = connect_db()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM job_tags")
+    cur.execute("UPDATE feedback SET tags=''")
+    conn.commit()
+    conn.close()
+    log_progress("Done")
+
+
 @app.post("/reprocess", response_class=HTMLResponse)
 def reprocess(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
@@ -515,6 +527,13 @@ def regen_jobs(
 def consolidate_tags_endpoint(request: Request, background_tasks: BackgroundTasks):
     progress_logs.clear()
     background_tasks.add_task(consolidate_tags_task)
+    return templates.TemplateResponse("progress.html", {"request": request})
+
+
+@app.post("/delete_tags", response_class=HTMLResponse)
+def delete_tags(request: Request, background_tasks: BackgroundTasks):
+    progress_logs.clear()
+    background_tasks.add_task(clear_tags_task)
     return templates.TemplateResponse("progress.html", {"request": request})
 
 

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -11,6 +11,9 @@
 <form class="mt-3" method="post" action="/delete_ai" onsubmit="return confirm('Delete all summaries and embeddings?');">
   <button class="btn btn-danger" type="submit">Delete AI Data</button>
 </form>
+<form class="mt-3" method="post" action="/delete_tags" onsubmit="return confirm('Delete all tags?');">
+  <button class="btn btn-danger" type="submit">Delete Tags</button>
+</form>
 <form class="mt-3" method="post" action="/consolidate_tags" onsubmit="return confirm('Merge similar tags?');">
   <button class="btn btn-secondary" type="submit">Consolidate Tags</button>
 </form>

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -112,3 +112,59 @@ def test_embedding_includes_title_company(ai_module, tmp_path, monkeypatch):
     text = captured.get("text", "")
     assert "Data Scientist" in text
     assert "ACME" in text
+
+
+def test_process_all_jobs_generates_tags(ai_module, tmp_path, monkeypatch):
+    ai = ai_module
+    stub_main = sys.modules["app.main"]
+    db_path = tmp_path / "tags.db"
+    stub_main.DATABASE = str(db_path)
+
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE jobs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            company TEXT,
+            description TEXT,
+            min_amount REAL,
+            max_amount REAL
+        )
+        """
+    )
+    cur.execute("CREATE TABLE summaries(job_id INTEGER PRIMARY KEY, summary TEXT)")
+    cur.execute(
+        "CREATE TABLE embeddings(job_id INTEGER PRIMARY KEY, embedding TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE clean_jobs(job_id INTEGER PRIMARY KEY, title TEXT, company TEXT, min_amount REAL, max_amount REAL)"
+    )
+    cur.execute(
+        "CREATE TABLE job_tags(job_id INTEGER, tag TEXT, PRIMARY KEY(job_id, tag))"
+    )
+    cur.execute(
+        "INSERT INTO jobs(id,title,company,description,min_amount,max_amount) VALUES(1,'Dev','C','do stuff',1,2)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(ai, "OLLAMA_ENABLED", True)
+    monkeypatch.setattr(ai, "embed_text", lambda x: [])
+    monkeypatch.setattr(ai, "generate_summary", lambda x: "")
+    monkeypatch.setattr(ai, "generate_tags", lambda x: ["Python", "SQL"])
+    monkeypatch.setattr(ai, "clean_title", lambda x: x)
+    monkeypatch.setattr(ai, "clean_company", lambda x: x)
+    monkeypatch.setattr(ai, "infer_salary", lambda x: None)
+
+    ai.process_all_jobs()
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT tag FROM job_tags ORDER BY tag")
+    tags = [r[0] for r in cur.fetchall()]
+    conn.close()
+    assert tags == ["Python", "SQL"]


### PR DESCRIPTION
## Summary
- allow deleting tags via `/delete_tags` endpoint and button on manage page
- ensure tag data regenerates when processing jobs
- test new tag functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826d7715308330a8857e5871f19a24