### PR TITLE
Interactive tag consolidation and per-job tag actions

### DIFF
--- a/app/templates/consolidate.html
+++ b/app/templates/consolidate.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Review Tag Consolidation{% endblock %}
+{% block content %}
+<h1 class="mb-4">Possible Tag Consolidation</h1>
+{% if not pair %}
+<p>No similar tags found.</p>
+{% else %}
+<p class="mb-3"><strong>{{ remaining }}</strong> potential pair{{ remaining!=1 and 's' or '' }} remaining.</p>
+<div class="card mb-3">
+  <div class="card-body">
+    <p><strong>{{ pair[0] }}</strong> (Φ={{ '{:.2f}'.format(pair[3]) }}, count={{ pair[5] }})</p>
+    <p><strong>{{ pair[1] }}</strong> (Φ={{ '{:.2f}'.format(pair[4]) }}, count={{ pair[6] }})</p>
+    <p>Similarity: {{ '{:.2f}'.format(pair[2]) }}</p>
+  </div>
+</div>
+<form method="post" action="/consolidate_tags_action" class="mt-3 d-flex justify-content-center gap-3">
+  <input type="hidden" name="pair_tags" value="{{ pair[0] }},{{ pair[1] }}" />
+  <button class="btn btn-success" name="merge" value="1" type="submit">Merge</button>
+  <button class="btn btn-secondary" name="merge" value="0" type="submit">Keep Separate</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/app/templates/manage.html
+++ b/app/templates/manage.html
@@ -11,10 +11,7 @@
 <form class="mt-3" method="post" action="/delete_ai" onsubmit="return confirm('Delete all summaries and embeddings?');">
   <button class="btn btn-danger" type="submit">Delete AI Data</button>
 </form>
-<form class="mt-3" method="post" action="/delete_tags" onsubmit="return confirm('Delete all tags?');">
-  <button class="btn btn-danger" type="submit">Delete Tags</button>
-</form>
-<form class="mt-3" method="post" action="/consolidate_tags" onsubmit="return confirm('Merge similar tags?');">
+<form class="mt-3" method="get" action="/consolidate_tags">
   <button class="btn btn-secondary" type="submit">Consolidate Tags</button>
 </form>
 <form class="mt-3" method="get" action="/export_likes">

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -2,8 +2,10 @@
 {% block title %}Job Stats{% endblock %}
 {% block content %}
 <h1 class="mb-4">Job Feedback</h1>
-<form method="post" action="/regen_jobs" onsubmit="return confirm('Regenerate AI data for selected jobs?');">
-  <button class="btn btn-sm btn-secondary mb-2" type="submit">Regenerate Selected</button>
+<form method="post" id="job-actions-form">
+  <button class="btn btn-sm btn-secondary mb-2 me-2" formaction="/regen_jobs" onclick="return confirm('Regenerate AI data for selected jobs?');" type="submit">Regenerate Selected</button>
+  <button class="btn btn-sm btn-primary mb-2 me-2" formaction="/add_tags" onclick="return confirm('Add tags to selected jobs?');" type="submit">Add Tags</button>
+  <button class="btn btn-sm btn-danger mb-2" formaction="/delete_tags" onclick="return confirm('Delete tags for selected jobs?');" type="submit">Delete Tags</button>
   <table class="table table-striped data-table">
     <thead>
       <tr><th>Select</th><th>#</th><th>Title</th><th>Company</th><th>Posted</th><th>AI</th><th></th></tr>


### PR DESCRIPTION
## Summary
- add `not_tag_merges` table and helper utilities for tag merging
- implement `find_similar_tags` and tag merge endpoints
- add background tasks to add or clear tags for selected roles
- remove global delete tags button and use per-role actions
- introduce consolidation approval UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688270ea1c8883309f27a926a27b4ba3